### PR TITLE
feat: apigateway lambda integration

### DIFF
--- a/.github/workflows/terraform-security-scan.yml
+++ b/.github/workflows/terraform-security-scan.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Checkov security scan
-        uses: bridgecrewio/checkov-action@f621ecfe2d83b0e2028c7e93f082812eb56d3743 # latest as of Sept 9, 2021
+        uses: bridgecrewio/checkov-action@d259454a31835b99ea6cf9aa1c2d08190f2f65c9 # latest as of Sept 9, 2021
         with:
           directory: terragrunt/aws
           framework: terraform

--- a/.github/workflows/terraform-security-scan.yml
+++ b/.github/workflows/terraform-security-scan.yml
@@ -23,7 +23,9 @@ jobs:
       - name: Checkov security scan
         uses: bridgecrewio/checkov-action@d259454a31835b99ea6cf9aa1c2d08190f2f65c9 # latest as of November 16, 2021
         with:
+          config_file: terragrunt/.checkov.yml
           directory: terragrunt/aws
           framework: terraform
           output_format: cli
+          quiet: true
           soft_fail: false

--- a/.github/workflows/terraform-security-scan.yml
+++ b/.github/workflows/terraform-security-scan.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Checkov security scan
-        uses: bridgecrewio/checkov-action@d259454a31835b99ea6cf9aa1c2d08190f2f65c9 # latest as of Sept 9, 2021
+        uses: bridgecrewio/checkov-action@d259454a31835b99ea6cf9aa1c2d08190f2f65c9 # latest as of November 16, 2021
         with:
           directory: terragrunt/aws
           framework: terraform

--- a/terragrunt/.checkov.yml
+++ b/terragrunt/.checkov.yml
@@ -1,0 +1,10 @@
+skip-check:
+  - CKV_AWS_51  # ECR: `latest` tag is used for development
+  - CKV_AWS_59  # API Gateway: anonymous access required by API
+  - CKV_AWS_73  # API Gateway: X-ray tracing not required
+  - CKV_AWS_109 # KMS: `resources=["*"]` references the key the policy is attached to
+  - CKV_AWS_111 # MKS: `resources=["*"]` references the key the policy is attached to
+  - CKV_AWS_117 # Lambda: access to VPC resources not required
+  - CKV_AWS_120 # API Gateway: caching is not wanted
+  - CKV_AWS_136 # ECR: default encryption key is acceptable 
+  - CKV_AWS_158 # CloudWatch: default encryption key is acceptable

--- a/terragrunt/.checkov.yml
+++ b/terragrunt/.checkov.yml
@@ -2,8 +2,6 @@ skip-check:
   - CKV_AWS_51  # ECR: `latest` tag is used for development
   - CKV_AWS_59  # API Gateway: anonymous access required by API
   - CKV_AWS_73  # API Gateway: X-ray tracing not required
-  - CKV_AWS_109 # KMS: `resources=["*"]` references the key the policy is attached to
-  - CKV_AWS_111 # MKS: `resources=["*"]` references the key the policy is attached to
   - CKV_AWS_117 # Lambda: access to VPC resources not required
   - CKV_AWS_120 # API Gateway: caching is not wanted
   - CKV_AWS_136 # ECR: default encryption key is acceptable 

--- a/terragrunt/aws/api/api_gateway.tf
+++ b/terragrunt/aws/api/api_gateway.tf
@@ -19,7 +19,6 @@ resource "aws_api_gateway_resource" "resource" {
 }
 
 resource "aws_api_gateway_method" "method" {
-  # checkov:skip=CKV_AWS_59: Public access is required for this API.  Sensitive methods are protected by an API auth key.
   rest_api_id   = aws_api_gateway_rest_api.api.id
   resource_id   = aws_api_gateway_resource.resource.id
   http_method   = "ANY"

--- a/terragrunt/aws/api/api_gateway.tf
+++ b/terragrunt/aws/api/api_gateway.tf
@@ -5,6 +5,11 @@ resource "aws_api_gateway_rest_api" "api" {
   endpoint_configuration {
     types = ["REGIONAL"]
   }
+
+  tags = {
+    CostCenter = var.billing_code
+    Terraform  = true
+  }
 }
 
 resource "aws_api_gateway_resource" "resource" {
@@ -24,6 +29,17 @@ resource "aws_api_gateway_method" "method" {
   }
 }
 
+resource "aws_api_gateway_method_settings" "all" {
+  rest_api_id = aws_api_gateway_rest_api.api.id
+  stage_name  = aws_api_gateway_stage.api.stage_name
+  method_path = "*/*"
+
+  settings {
+    metrics_enabled = true
+    logging_level   = "ERROR"
+  }
+}
+
 resource "aws_api_gateway_method_response" "api_response_200" {
   rest_api_id = aws_api_gateway_rest_api.api.id
   resource_id = aws_api_gateway_resource.resource.id
@@ -32,5 +48,55 @@ resource "aws_api_gateway_method_response" "api_response_200" {
 
   response_models = {
     "application/json" = "Empty"
+  }
+
+  response_parameters = {
+    "method.response.header.Strict-Transport-Security" = true
+  }
+}
+
+resource "aws_api_gateway_integration" "integration" {
+  rest_api_id = aws_api_gateway_rest_api.api.id
+  resource_id = aws_api_gateway_resource.resource.id
+  http_method = aws_api_gateway_method.method.http_method
+
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = module.api.function_arn
+
+  request_parameters = {
+    "integration.request.path.proxy" = "method.request.path.proxy"
+  }
+}
+
+resource "aws_api_gateway_integration_response" "integration_response" {
+  rest_api_id = aws_api_gateway_rest_api.api.id
+  resource_id = aws_api_gateway_resource.resource.id
+  http_method = aws_api_gateway_method.method.http_method
+  status_code = aws_api_gateway_method_response.api_response_200.status_code
+
+  response_templates = {
+    "application/json" = ""
+  }
+}
+
+resource "aws_api_gateway_deployment" "api" {
+  rest_api_id       = aws_api_gateway_rest_api.api.id
+  stage_description = md5(file("api_gateway.tf"))
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_api_gateway_stage" "api" {
+  # checkov:skip=CKV2_AWS_29: False-positive, API stage is associated with WAF ACL in ./waf.tf
+  deployment_id = aws_api_gateway_deployment.api.id
+  rest_api_id   = aws_api_gateway_rest_api.api.id
+  stage_name    = "v1"
+
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.api_access.arn
+    format          = "{\"requestId\":\"$context.requestId\", \"ip\": \"$context.identity.sourceIp\", \"caller\":\"$context.identity.caller\", \"requestTime\":\"$context.requestTime\", \"httpMethod\":\"$context.httpMethod\", \"resourcePath\":\"$context.resourcePath\", \"status\":\"$context.status\", \"responseLength\":\"$context.responseLength\"}"
   }
 }

--- a/terragrunt/aws/api/api_gateway.tf
+++ b/terragrunt/aws/api/api_gateway.tf
@@ -61,7 +61,7 @@ resource "aws_api_gateway_integration" "integration" {
 
   integration_http_method = "POST"
   type                    = "AWS_PROXY"
-  uri                     = module.api.function_arn
+  uri                     = module.api.invoke_arn
 
   request_parameters = {
     "integration.request.path.proxy" = "method.request.path.proxy"

--- a/terragrunt/aws/api/cloudwatch_log.tf
+++ b/terragrunt/aws/api/cloudwatch_log.tf
@@ -2,7 +2,6 @@
 # API Gateway CloudWatch logging
 #
 resource "aws_cloudwatch_log_group" "api_access" {
-  # checkov:skip=CKV_AWS_158: CloudWatch default encryption key is acceptable
   name              = "/aws/api-gateway/api-access"
   retention_in_days = 14
 

--- a/terragrunt/aws/api/cloudwatch_log.tf
+++ b/terragrunt/aws/api/cloudwatch_log.tf
@@ -5,6 +5,11 @@ resource "aws_cloudwatch_log_group" "api_access" {
   # checkov:skip=CKV_AWS_158: CloudWatch default encryption key is acceptable
   name              = "/aws/api-gateway/api-access"
   retention_in_days = 14
+
+  tags = {
+    CostCenter = var.billing_code
+    Terraform  = true
+  }
 }
 
 # This account will be used by all API Gateway resources in the account and region
@@ -15,6 +20,11 @@ resource "aws_api_gateway_account" "api_cloudwatch" {
 resource "aws_iam_role" "api_cloudwatch" {
   name               = "ApiGatewayCloudWatchRole"
   assume_role_policy = data.aws_iam_policy_document.api_assume.json
+
+  tags = {
+    CostCenter = var.billing_code
+    Terraform  = true
+  }
 }
 
 resource "aws_iam_role_policy_attachment" "api_cloudwatch" {

--- a/terragrunt/aws/api/ecr.tf
+++ b/terragrunt/aws/api/ecr.tf
@@ -1,7 +1,4 @@
 resource "aws_ecr_repository" "api" {
-  # checkov:skip=CKV_AWS_51:The :latest tag is used in Staging
-  # checkov:skip=CKV_AWS_136: ECR encryption with default KMS key is acceptable
-
   name                 = "${var.product_name}/api"
   image_tag_mutability = "MUTABLE"
 

--- a/terragrunt/aws/api/ecr.tf
+++ b/terragrunt/aws/api/ecr.tf
@@ -8,4 +8,9 @@ resource "aws_ecr_repository" "api" {
   image_scanning_configuration {
     scan_on_push = true
   }
+
+  tags = {
+    CostCenter = var.billing_code
+    Terraform  = true
+  }
 }

--- a/terragrunt/aws/api/iam.tf
+++ b/terragrunt/aws/api/iam.tf
@@ -58,6 +58,11 @@ resource "aws_iam_role_policy_attachment" "api" {
 resource "aws_iam_role" "waf_log_role" {
   name               = "${var.product_name}-logs"
   assume_role_policy = data.aws_iam_policy_document.firehose_assume_role.json
+
+  tags = {
+    CostCenter = var.billing_code
+    Terraform  = true
+  }
 }
 
 resource "aws_iam_policy" "write_waf_logs" {

--- a/terragrunt/aws/api/iam.tf
+++ b/terragrunt/aws/api/iam.tf
@@ -14,6 +14,11 @@ data "aws_iam_policy_document" "service_principal" {
 resource "aws_iam_role" "api" {
   name               = "${var.product_name}-api"
   assume_role_policy = data.aws_iam_policy_document.service_principal.json
+
+  tags = {
+    CostCenter = var.billing_code
+    Terraform  = true
+  }
 }
 
 data "aws_iam_policy_document" "api_policies" {
@@ -38,6 +43,11 @@ resource "aws_iam_policy" "api" {
   name   = "${var.product_name}-api"
   path   = "/"
   policy = data.aws_iam_policy_document.api_policies.json
+
+  tags = {
+    CostCenter = var.billing_code
+    Terraform  = true
+  }
 }
 
 resource "aws_iam_role_policy_attachment" "api" {
@@ -54,6 +64,11 @@ resource "aws_iam_policy" "write_waf_logs" {
   name        = "${var.product_name}_WriteLogs"
   description = "Allow writing WAF logs to S3 + CloudWatch"
   policy      = data.aws_iam_policy_document.write_waf_logs.json
+
+  tags = {
+    CostCenter = var.billing_code
+    Terraform  = true
+  }
 }
 
 resource "aws_iam_role_policy_attachment" "write_waf_logs" {

--- a/terragrunt/aws/api/kms.tf
+++ b/terragrunt/aws/api/kms.tf
@@ -1,5 +1,7 @@
 
 data "aws_iam_policy_document" "kms_policies" {
+  # checkov:skip=CKV_AWS_109: `resources=["*"]` references the key the policy is attached to
+  # checkov:skip=CKV_AWS_111: `resources=["*"]` references the key the policy is attached to
   statement {
 
     effect = "Allow"

--- a/terragrunt/aws/api/kms.tf
+++ b/terragrunt/aws/api/kms.tf
@@ -1,8 +1,5 @@
 
 data "aws_iam_policy_document" "kms_policies" {
-  # checkov:skip=CKV_AWS_109: `resources=["*"]` references the key the policy is attached to
-  # checkov:skip=CKV_AWS_111: `resources=["*"]` references the key the policy is attached to
-
   statement {
 
     effect = "Allow"

--- a/terragrunt/aws/api/kms.tf
+++ b/terragrunt/aws/api/kms.tf
@@ -68,4 +68,9 @@ resource "aws_kms_key" "scan-files" {
   enable_key_rotation = true
 
   policy = data.aws_iam_policy_document.kms_policies.json
+
+  tags = {
+    CostCenter = var.billing_code
+    Terraform  = true
+  }
 }

--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -1,5 +1,5 @@
 module "api" {
-  source                   = "github.com/cds-snc/terraform-modules?ref=v0.0.44//lambda"
+  source                   = "github.com/cds-snc/terraform-modules?ref=v0.0.45//lambda"
   name                     = "api"
   billing_tag_value        = var.billing_code
   allow_api_gateway_invoke = true

--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -12,6 +12,11 @@ module "api" {
     subnet_ids         = module.vpc.private_subnet_ids
   }
 
+  environment_variables = {
+    API_AUTH_TOKEN          = var.api_auth_token
+    SQLALCHEMY_DATABASE_URI = module.rds.proxy_connection_string_value
+  }
+
   policies = [
     data.aws_iam_policy_document.api_policies.json,
   ]

--- a/terragrunt/aws/api/waf.tf
+++ b/terragrunt/aws/api/waf.tf
@@ -154,7 +154,6 @@ resource "aws_wafv2_web_acl" "api_waf" {
 }
 
 resource "aws_cloudwatch_log_group" "api_waf" {
-  # checkov:skip=CKV_AWS_158: CloudWatch default encryption key is acceptable
   name              = "/aws/kinesisfirehose/api_waf"
   retention_in_days = 14
 

--- a/terragrunt/aws/api/waf.tf
+++ b/terragrunt/aws/api/waf.tf
@@ -3,6 +3,11 @@ resource "aws_wafv2_web_acl" "api_waf" {
   description = "WAF for API protection"
   scope       = "REGIONAL"
 
+  tags = {
+    CostCenter = var.billing_code
+    Terraform  = true
+  }
+
   default_action {
     allow {}
   }
@@ -152,6 +157,11 @@ resource "aws_cloudwatch_log_group" "api_waf" {
   # checkov:skip=CKV_AWS_158: CloudWatch default encryption key is acceptable
   name              = "/aws/kinesisfirehose/api_waf"
   retention_in_days = 14
+
+  tags = {
+    CostCenter = var.billing_code
+    Terraform  = true
+  }
 }
 
 resource "aws_kinesis_firehose_delivery_stream" "api_waf" {
@@ -167,6 +177,11 @@ resource "aws_kinesis_firehose_delivery_stream" "api_waf" {
       log_group_name  = aws_cloudwatch_log_group.api_waf.name
       log_stream_name = "WAFLogS3Delivery"
     }
+  }
+
+  tags = {
+    CostCenter = var.billing_code
+    Terraform  = true
   }
 }
 

--- a/terragrunt/env/common/provider.tf
+++ b/terragrunt/env/common/provider.tf
@@ -1,11 +1,4 @@
 provider "aws" {
   region              = var.region
   allowed_account_ids = [var.account_id]
-
-  default_tags {
-    tags = {
-      CostCentre = var.billing_code
-      Terraform  = "True"
-    }
-  }
 }


### PR DESCRIPTION
Integrate lambda with api gateway. Will fix any outstanding confest issues in a subsequent PR's due to the default_tags needing to be removed this cycle and causing opa_check failures even though the tag exists.