### PR TITLE
fix: commit scan id before using as metadata

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -26,7 +26,16 @@ services:
     environment:
       SHELL: /bin/zsh
       <<: *db-connection-strings
- 
+  api:
+    build:
+      context: ../api/
+    volumes:
+      - ../api:/function
+    environment:
+      <<: *db-connection-strings
+      AWS_LOCALSTACK: "True"
+      OPENAPI_URL: "/openapi.json"
+
   db:
     image: postgres:11.2
     volumes:

--- a/api/api_gateway/routers/scans.py
+++ b/api/api_gateway/routers/scans.py
@@ -43,6 +43,7 @@ def start_assemblyline_scan(
             file_name=file.filename, scan_provider=ScanProviders.ASSEMBLYLINE.value
         )
         session.add(scan)
+        session.commit()
 
         meta_data = {
             "git_sha": environ.get("GIT_SHA", "latest"),
@@ -55,7 +56,6 @@ def start_assemblyline_scan(
             params=settings,
             metadata=meta_data,
         )
-        session.commit()
     except Exception as err:
         log.error(err)
         response.status_code = status.HTTP_502_BAD_GATEWAY


### PR DESCRIPTION
Scan id is now available before the call to assemblyline

fixes: #9 