### PR TITLE
feat: increase wait times and lambda timeout

### DIFF
--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -7,6 +7,8 @@ module "api" {
   ecr_arn                  = aws_ecr_repository.api.arn
   enable_lambda_insights   = true
   image_uri                = "${aws_ecr_repository.api.repository_url}:latest"
+  timeout                  = 120
+
   vpc = {
     security_group_ids = [module.rds.proxy_security_group_id, aws_security_group.api.id]
     subnet_ids         = module.vpc.private_subnet_ids

--- a/terragrunt/env/scan_queue/terragrunt.hcl
+++ b/terragrunt/env/scan_queue/terragrunt.hcl
@@ -19,7 +19,7 @@ dependency "api" {
 
 inputs = {
   concurrent_scan_limit  = 10
-  retry_interval_seconds = 60
+  retry_interval_seconds = 120
   api_function_arn       = dependency.api.outputs.function_arn
   api_function_name      = dependency.api.outputs.function_name
 }


### PR DESCRIPTION
Increase lambda timeout to allow time for file I/O and increase polling frequency to reduce calls to AssemblyLine.

Closes #22 