### PR TITLE
feat: API stage custom domain and certificate

### DIFF
--- a/terragrunt/aws/api/api_gateway.tf
+++ b/terragrunt/aws/api/api_gateway.tf
@@ -12,6 +12,21 @@ resource "aws_api_gateway_rest_api" "api" {
   }
 }
 
+resource "aws_api_gateway_domain_name" "api" {
+  regional_certificate_arn = aws_acm_certificate_validation.scan_files_certificate_validation.certificate_arn
+  domain_name              = var.domain_name
+  security_policy          = "TLS_1_2"
+
+  endpoint_configuration {
+    types = ["REGIONAL"]
+  }
+}
+
+resource "aws_api_gateway_base_path_mapping" "api" {
+  api_id      = aws_api_gateway_rest_api.api.id
+  stage_name  = aws_api_gateway_stage.api.stage_name
+  domain_name = aws_api_gateway_domain_name.api.domain_name
+}
 resource "aws_api_gateway_resource" "resource" {
   rest_api_id = aws_api_gateway_rest_api.api.id
   parent_id   = aws_api_gateway_rest_api.api.root_resource_id

--- a/terragrunt/aws/api/api_gateway.tf
+++ b/terragrunt/aws/api/api_gateway.tf
@@ -20,6 +20,11 @@ resource "aws_api_gateway_domain_name" "api" {
   endpoint_configuration {
     types = ["REGIONAL"]
   }
+
+  tags = {
+    CostCentre = var.billing_code
+    Terraform  = true
+  }
 }
 
 resource "aws_api_gateway_base_path_mapping" "api" {

--- a/terragrunt/aws/api/certificate.tf
+++ b/terragrunt/aws/api/certificate.tf
@@ -4,7 +4,8 @@ resource "aws_acm_certificate" "scan_files_certificate" {
   validation_method         = "DNS"
 
   tags = {
-    CostCenter = var.billing_code
+    CostCentre = var.billing_code
+    Terraform  = true
   }
 
   lifecycle {

--- a/terragrunt/aws/api/certificate.tf
+++ b/terragrunt/aws/api/certificate.tf
@@ -1,0 +1,37 @@
+resource "aws_acm_certificate" "scan_files_certificate" {
+  domain_name               = var.domain_name
+  subject_alternative_names = ["*.${var.domain_name}"]
+  validation_method         = "DNS"
+
+  tags = {
+    CostCenter = var.billing_code
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_route53_record" "scan_files_dns_validation" {
+  zone_id = var.hosted_zone_id
+
+  for_each = {
+    for dvo in aws_acm_certificate.scan_files_certificate.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      type   = dvo.resource_record_type
+      record = dvo.resource_record_value
+    }
+  }
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  type            = each.value.type
+
+  ttl = 60
+}
+
+resource "aws_acm_certificate_validation" "scan_files_certificate_validation" {
+  certificate_arn         = aws_acm_certificate.scan_files_certificate.arn
+  validation_record_fqdns = [for record in aws_route53_record.scan_files_dns_validation : record.fqdn]
+}

--- a/terragrunt/aws/api/inputs.tf
+++ b/terragrunt/aws/api/inputs.tf
@@ -38,3 +38,11 @@ variable "completed_scans_table_name" {
 variable "scan_queue_statemachine_name" {
   type = string
 }
+
+variable "domain_name" {
+  type = string
+}
+
+variable "hosted_zone_id" {
+  type = string
+}

--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -23,6 +23,7 @@ module "api" {
     FILE_QUEUE_BUCKET            = module.file-queue.s3_bucket_id
     SCAN_QUEUE_STATEMACHINE_NAME = var.scan_queue_statemachine_name
     COMPLETED_SCANS_TABLE_NAME   = var.completed_scans_table_name
+    OPENAPI_URL                  = "/openapi.json" # Enable /docs api endpoint
   }
 
   policies = [

--- a/terragrunt/aws/api/route53.tf
+++ b/terragrunt/aws/api/route53.tf
@@ -1,0 +1,11 @@
+resource "aws_route53_record" "scan_files_A" {
+  zone_id = var.hosted_zone_id
+  name    = var.domain_name
+  type    = "A"
+
+  alias {
+    name                   = aws_api_gateway_domain_name.api.regional_domain_name
+    zone_id                = aws_api_gateway_domain_name.api.regional_zone_id
+    evaluate_target_health = false
+  }
+}

--- a/terragrunt/env/api/terragrunt.hcl
+++ b/terragrunt/env/api/terragrunt.hcl
@@ -2,8 +2,23 @@ terraform {
   source = "../../aws//api"
 }
 
+dependencies {
+  paths = ["../hosted_zone"]
+}
+
+dependency "hosted_zone" {
+  config_path = "../hosted_zone"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs = {
+    hosted_zone_id = ""
+  }
+}
+
 inputs = {
   rds_username = "databaseuser"
+  hosted_zone_id = dependency.hosted_zone.outputs.hosted_zone_id
+  domain_name    = "scan-files.alpha.canada.ca"
 }
 
 include {

--- a/terragrunt/env/api/terragrunt.hcl
+++ b/terragrunt/env/api/terragrunt.hcl
@@ -16,7 +16,7 @@ dependency "hosted_zone" {
 }
 
 inputs = {
-  rds_username = "databaseuser"
+  rds_username   = "databaseuser"
   hosted_zone_id = dependency.hosted_zone.outputs.hosted_zone_id
   domain_name    = "scan-files.alpha.canada.ca"
 }


### PR DESCRIPTION
- This creates a custom domain name, certificate and DNS "A" record for scan-files.alpha.canada.ca.
- Enables api documentation located at /docs

Closes #25 