### PR TITLE
feat: pin terraform to version 3

### DIFF
--- a/terragrunt/env/common/provider.tf
+++ b/terragrunt/env/common/provider.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}
+
 provider "aws" {
   region              = var.region
   allowed_account_ids = [var.account_id]


### PR DESCRIPTION
Pin AWS provider to version 3 in-order to prevent breaking changes.