### PR TITLE
fix: switch to generate SBOM composite action

### DIFF
--- a/.github/workflows/generate_sbom.yml
+++ b/.github/workflows/generate_sbom.yml
@@ -12,16 +12,20 @@ on:
       - main
     paths:
       - api/requirements.txt
-      - .github/workflows/generate_sbom.yml      
+      - .github/workflows/generate_sbom.yml
 
 jobs:
   generate-sbom:
-    name: Generate SBOM
-    uses: cds-snc/security-tools/.github/workflows/generate_sbom.yml@main
-    with:
-      project_name: scan-files/api
-      project_type: python
-      project_version: main
-      working_directory: api
-    secrets:
-      dependency_track_api_key: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Generate SBOM
+        uses: cds-snc/security-tools/.github/actions/generate-sbom@496f79b604b24dcbc905f22eb1abb7398566b1ec
+        with:
+          dependency_track_api_key: ${{ secrets.DEPENDENCY_TRACK_API_KEY }}
+          project_name: scan-files/api
+          project_type: python
+          project_version: main
+          working-directory: api

--- a/.github/workflows/generate_sbom.yml
+++ b/.github/workflows/generate_sbom.yml
@@ -28,4 +28,4 @@ jobs:
           project_name: scan-files/api
           project_type: python
           project_version: main
-          working-directory: api
+          working_directory: api


### PR DESCRIPTION
# Summary
The shared workflow in `security-tools` is being replaced with a
composite action.

# Related
* cds-snc/platform-sre-security-support#94