### PR TITLE
feat: group major and patch dependency bumps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,27 @@
 {
   "extends": [
     "config:base"
+  ],
+  "packageRules": [
+    {
+      "matchPackagePatterns": [
+        "*"
+      ],
+      "matchUpdateTypes": [
+        "patch"
+      ],
+      "groupName": "all patch dependencies",
+      "groupSlug": "all-patch"
+    },
+    {
+      "matchPackagePatterns": [
+        "*"
+      ],
+      "matchUpdateTypes": [
+        "minor"
+      ],
+      "groupName": "all minor dependencies",
+      "groupSlug": "all-minor"
+    }
   ]
 }


### PR DESCRIPTION
Currently by default renovate creates a PR for each dependencyupdate. This PR updates the renovate config to group major and patch dependecy bumps so make it more manageable. Major versions will continue to remain as individual PRs.