### PR TITLE
feat: exclude python from being grouped

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,9 @@
       "matchUpdateTypes": [
         "minor"
       ],
+      "excludePackageNames": [
+        "python"
+      ],
       "groupName": "all minor dependencies",
       "groupSlug": "all-minor"
     }


### PR DESCRIPTION
Excluding Python when minor dependency version updates are grouped.