### PR TITLE
feat: test out new default config setup

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,37 +1,5 @@
 {
-  "schedule": ["every weekend"],
   "extends": [
-    "config:base",
-    "helpers:pinGitHubActionDigests"
-  ],
-  "packageRules": [
-    {
-      "matchDatasources": ["docker"],
-      "matchPackageNames": ["python"],
-      "versioning": "pep440"
-    },
-    {
-      "matchPackagePatterns": [
-        "*"
-      ],
-      "matchUpdateTypes": [
-        "patch"
-      ],
-      "groupName": "all patch dependencies",
-      "groupSlug": "all-patch"
-    },
-    {
-      "matchPackagePatterns": [
-        "*"
-      ],
-      "matchUpdateTypes": [
-        "minor"
-      ],
-      "excludePackageNames": [
-        "python"
-      ],
-      "groupName": "all minor dependencies",
-      "groupSlug": "all-minor"
-    }
+    "github>cds-snc/renovate-config"
   ]
 }


### PR DESCRIPTION
This new setup should grab the default config from https://github.com/cds-snc/renovate-config. If this works out well, we can add this `renovate.json` to our github templates