### PR TITLE
feat: lambda envs no longer required

### DIFF
--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -14,18 +14,6 @@ module "api" {
     subnet_ids         = module.vpc.private_subnet_ids
   }
 
-  environment_variables = {
-    API_AUTH_TOKEN               = var.api_auth_token
-    SQLALCHEMY_DATABASE_URI      = module.rds.proxy_connection_string_value
-    MLWR_HOST                    = var.mlwr_host
-    MLWR_USER                    = var.mlwr_user
-    MLWR_KEY                     = var.mlwr_key
-    FILE_QUEUE_BUCKET            = module.file-queue.s3_bucket_id
-    SCAN_QUEUE_STATEMACHINE_NAME = var.scan_queue_statemachine_name
-    COMPLETED_SCANS_TABLE_NAME   = var.completed_scans_table_name
-    OPENAPI_URL                  = "/openapi.json" # Enable /docs api endpoint
-  }
-
   policies = [
     data.aws_iam_policy_document.api_policies.json,
   ]

--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -14,6 +14,11 @@ module "api" {
     subnet_ids         = module.vpc.private_subnet_ids
   }
 
+  environment_variables = {
+    SQLALCHEMY_DATABASE_URI = module.rds.proxy_connection_string_value
+    FILE_QUEUE_BUCKET       = module.file-queue.s3_bucket_id
+  }
+
   policies = [
     data.aws_iam_policy_document.api_policies.json,
   ]


### PR DESCRIPTION
Migrated to using `ssm` and `loadenv` in a previous PR. Majority of lambda envs are no longer required.