### PR TITLE
fix: write ssm env to /tmp

### DIFF
--- a/api/bin/entry.sh
+++ b/api/bin/entry.sh
@@ -4,6 +4,9 @@ if [ -z "${AWS_LAMBDA_RUNTIME_API}" ]; then
     exec find . -name "*.py" | entr -r /usr/bin/aws-lambda-rie /usr/local/bin/python -m awslambdaric "$1"
 else
     echo "Retrieving environment parameters"
-    aws ssm get-parameters --region ca-central-1 --with-decryption --names ENVIRONMENT_VARIABLES --query 'Parameters[*].Value' --output text > ".env"
+    ENV_PATH="/tmp/scanfiles"
+    mkdir "$ENV_PATH"
+    export DOTENV_PATH="$ENV_PATH"
+    aws ssm get-parameters --region ca-central-1 --with-decryption --names ENVIRONMENT_VARIABLES --query 'Parameters[*].Value' --output text > "$ENV_PATH/.env"
     exec /usr/local/bin/python -m awslambdaric "$1"
 fi

--- a/api/main.py
+++ b/api/main.py
@@ -13,7 +13,12 @@ from mangum import Mangum
 from os import environ
 
 
-load_dotenv()
+def setup_module():
+    if environ.get("DOTENV_PATH"):
+        load_dotenv(f"{environ.get('DOTENV_PATH')}/.env")
+
+
+setup_module()
 app = api.app
 metrics = Metrics(namespace="ScanFiles", service="api")
 

--- a/api/tests/test_main.py
+++ b/api/tests/test_main.py
@@ -1,5 +1,6 @@
-import main
 import json
+import main
+import os
 from unittest.mock import MagicMock, patch
 
 
@@ -96,3 +97,16 @@ def test_handler_migrate_event_failed(mock_migrate_head, context_fixture):
     mock_migrate_head.side_effect = Exception()
     assert main.handler({"task": "migrate"}, context_fixture) == "Error"
     mock_migrate_head.assert_called_once()
+
+
+def test_dotenv(tmp_path):
+    with patch.dict(os.environ, {"DOTENV_PATH": str(tmp_path / "scanfiles/.env")}, clear=True):
+        file = tmp_path / "scanfiles/.env"
+        file.parent.mkdir()
+        file.touch()
+        file.write_text("FOO=BAR")
+
+        import main
+        with patch("main.load_dotenv") as mock_load_dotenv:
+            main.setup_module()
+            mock_load_dotenv.assert_called_once()

--- a/api/tests/test_main.py
+++ b/api/tests/test_main.py
@@ -100,13 +100,16 @@ def test_handler_migrate_event_failed(mock_migrate_head, context_fixture):
 
 
 def test_dotenv(tmp_path):
-    with patch.dict(os.environ, {"DOTENV_PATH": str(tmp_path / "scanfiles/.env")}, clear=True):
+    with patch.dict(
+        os.environ, {"DOTENV_PATH": str(tmp_path / "scanfiles/.env")}, clear=True
+    ):
         file = tmp_path / "scanfiles/.env"
         file.parent.mkdir()
         file.touch()
         file.write_text("FOO=BAR")
 
         import main
+
         with patch("main.load_dotenv") as mock_load_dotenv:
             main.setup_module()
             mock_load_dotenv.assert_called_once()


### PR DESCRIPTION
Lambda only allows writes to the `/tmp` folder so the aws ssm parameter `.env` retrieval has been updated