### PR TITLE
refactor: load envs in entrypoint

### DIFF
--- a/api/bin/entry.sh
+++ b/api/bin/entry.sh
@@ -1,12 +1,49 @@
 #!/bin/sh
+# shellcheck disable=SC2120
+
+ENV_PATH="/tmp/scanfiles"
+TMP_ENV_FILE="$ENV_PATH/.env"
+
+var_expand() {
+  if [ -z "${1-}" ] || [ $# -ne 1 ]; then
+    printf 'var_expand: expected one argument\n' >&2;
+    return 1;
+  fi
+  eval printf '%s' "\"\${$1?}\"" 2> /dev/null # Variable double substitution to be able to check for variable
+}
+
+load_non_existing_envs() {
+  _isComment='^[[:space:]]*#'
+  _isBlank='^[[:space:]]*$'
+  while IFS= read -r line; do
+    if echo "$line" | grep -Eq "$_isComment"; then # Ignore comment line
+      continue
+    fi
+    if echo "$line" | grep -Eq "$_isBlank"; then # Ignore blank line
+      continue
+    fi
+    key=$(echo "$line" | cut -d '=' -f 1)
+    value=$(echo "$line" | cut -d '=' -f 2-)
+
+    if [ -z "$(var_expand "$key")" ]; then # Check if environment variable doesn't exist
+      export "${key}=${value}"
+    fi
+    
+  done < $TMP_ENV_FILE
+}
+
 if [ -z "${AWS_LAMBDA_RUNTIME_API}" ]; then
     echo "Running aws-lambda-rie"
     exec find . -name "*.py" | entr -r /usr/bin/aws-lambda-rie /usr/local/bin/python -m awslambdaric "$1"
 else
-    echo "Retrieving environment parameters"
-    ENV_PATH="/tmp/scanfiles"
-    mkdir "$ENV_PATH"
-    export DOTENV_PATH="$ENV_PATH"
-    aws ssm get-parameters --region ca-central-1 --with-decryption --names ENVIRONMENT_VARIABLES --query 'Parameters[*].Value' --output text > "$ENV_PATH/.env"
+    if [ ! -f "$ENV_PATH/.env" ]; then # Only setup envs once per lambda lifecycle
+      echo "Retrieving environment parameters"
+      if [ ! -d "$ENV_PATH" ]; then
+        mkdir "$ENV_PATH"
+      fi
+      aws ssm get-parameters --region ca-central-1 --with-decryption --names ENVIRONMENT_VARIABLES --query 'Parameters[*].Value' --output text > "$TMP_ENV_FILE"
+    fi
+    load_non_existing_envs
+
     exec /usr/local/bin/python -m awslambdaric "$1"
 fi

--- a/api/main.py
+++ b/api/main.py
@@ -7,18 +7,11 @@ from assemblyline.assemblyline import (
 from aws_lambda_powertools import Metrics
 from database.dynamodb import get_scan_result
 from database.migrate import migrate_head
-from dotenv import load_dotenv
 from logger import log
 from mangum import Mangum
 from os import environ
 
 
-def setup_module():
-    if environ.get("DOTENV_PATH"):
-        load_dotenv(f"{environ.get('DOTENV_PATH')}/.env")
-
-
-setup_module()
 app = api.app
 metrics = Metrics(namespace="ScanFiles", service="api")
 

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -8,4 +8,3 @@ mangum==0.15.0
 psycopg2-binary==2.9.3
 python-multipart
 SQLAlchemy==1.4.37
-python-dotenv==0.20.0

--- a/api/tests/test_main.py
+++ b/api/tests/test_main.py
@@ -97,19 +97,3 @@ def test_handler_migrate_event_failed(mock_migrate_head, context_fixture):
     mock_migrate_head.side_effect = Exception()
     assert main.handler({"task": "migrate"}, context_fixture) == "Error"
     mock_migrate_head.assert_called_once()
-
-
-def test_dotenv(tmp_path):
-    with patch.dict(
-        os.environ, {"DOTENV_PATH": str(tmp_path / "scanfiles/.env")}, clear=True
-    ):
-        file = tmp_path / "scanfiles/.env"
-        file.parent.mkdir()
-        file.touch()
-        file.write_text("FOO=BAR")
-
-        import main
-
-        with patch("main.load_dotenv") as mock_load_dotenv:
-            main.setup_module()
-            mock_load_dotenv.assert_called_once()

--- a/api/tests/test_main.py
+++ b/api/tests/test_main.py
@@ -1,6 +1,5 @@
 import json
 import main
-import os
 from unittest.mock import MagicMock, patch
 
 


### PR DESCRIPTION
`python-dotenv` doesn't work across files. Instead of using a singleton approach i've decided to setup the env in the dockerfile. This will make it more consistent across environments. Code copied from `notification-api` setup.