### PR TITLE
fix: schedule expression syntax

### DIFF
--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -55,7 +55,7 @@ resource "aws_cloudwatch_event_target" "trigger_api_lambda_to_rescan" {
 resource "aws_cloudwatch_event_rule" "clamav_update_avdefs" {
   name                = "clamav-update-avdefs-${var.env}"
   description         = "Updates ClamAV virus database every 2 hours"
-  schedule_expression = "rate(2 hour)"
+  schedule_expression = "rate(2 hours)"
   is_enabled          = false # Disabled until we have a working solution
 
   tags = {


### PR DESCRIPTION
For rate expressions any value greater than 1 must be plural