### PR TITLE
feat: increase memory to account for clamav

### DIFF
--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -7,6 +7,7 @@ module "api" {
   ecr_arn                  = aws_ecr_repository.api.arn
   enable_lambda_insights   = true
   image_uri                = "${aws_ecr_repository.api.repository_url}:latest"
+  memory                   = 1536
   timeout                  = 300
 
   vpc = {


### PR DESCRIPTION
ClamAV was unable to run with the default lambda memory size of 256MB. ClamAV uses on average of 1GB of memory. Bumping the memory to 1024 + 256 (original) + 256 (buffer) = 1536.