### PR TITLE
feat: scan files from s3 bucket

### DIFF
--- a/api/Makefile
+++ b/api/Makefile
@@ -29,7 +29,7 @@ migrations:
 	alembic upgrade head
 
 test:
-	API_AUTH_TOKEN=e184bd87-feac-4582-8ec8-dc63557faa68 CI=True coverage run -m pytest -k $(test_case) -s -vv tests &&\
+	API_AUTH_TOKEN=e184bd87-feac-4582-8ec8-dc63557faa68 OPENAPI_URL="" CI=True coverage run -m pytest -k $(test_case) -s -vv tests &&\
 	coverage report -m
 
 fmt-ci:

--- a/api/assemblyline/assemblyline.py
+++ b/api/assemblyline/assemblyline.py
@@ -142,6 +142,7 @@ def resubmit_stale_scans():
                 and_(
                     Scan.verdict == None,  # noqa
                     Scan.submitted < one_day_ago,
+                    Scan.save_path != None,  # noqa
                 )
             )
             .all()

--- a/api/clamav_scanner/clamav.py
+++ b/api/clamav_scanner/clamav.py
@@ -183,7 +183,7 @@ def scan_file(path):
     av_env["LD_LIBRARY_PATH"] = CLAMAVLIB_PATH
     log.info("Starting clamscan of %s." % path)
 
-    if "s3" in path:
+    if path.startswith("s3://"):
         try:
             save_path = f"{AV_DEFINITION_PATH}/quarantine/{str(uuid4())}"
             create_dir(f"{AV_DEFINITION_PATH}/quarantine")

--- a/api/clamav_scanner/scan.py
+++ b/api/clamav_scanner/scan.py
@@ -68,7 +68,7 @@ def launch_scan(file_path, scan_id, session=None, sns_arn=None):
         scan.meta_data = {AV_SIGNATURE_METADATA: scan_signature}
         log.info("Scan of %s resulted in %s\n" % (file_path, scan_result))
     except Exception as err:
-        log.error("Scan failed. Reason %s" % str(err))
+        log.error("Scan %s failed. Reason %s" % (str(scan.id), str(err)))
         scan.completed = datetime.datetime.utcnow()
         scan.verdict = ScanVerdicts.ERROR.value
         scan_signature = AV_SIGNATURE_UNKNOWN

--- a/api/tests/api_gateway/test_clamav_scans.py
+++ b/api/tests/api_gateway/test_clamav_scans.py
@@ -5,8 +5,10 @@ from factories import ScanFactory
 from fastapi.testclient import TestClient
 from models.Scan import Scan, ScanVerdicts
 from sqlalchemy.exc import SQLAlchemyError
-from unittest.mock import patch, MagicMock
+from unittest.mock import ANY, patch, MagicMock
 from clamav_scanner.common import create_dir
+from tempfile import TemporaryFile
+from clamav_scanner.common import AV_SIGNATURE_OK, AV_STATUS_CLEAN
 
 client = TestClient(api.app)
 
@@ -71,6 +73,148 @@ def test_clamav_start_scan(mock_db_session, mock_launch_scan):
     )
 
     mock_launch_scan.assert_called_once()
+
+
+@patch("clamav_scanner.scan.scan_file")
+@patch("clamav_scanner.scan.get_session")
+@patch("clamav_scanner.scan.sns_scan_results")
+@patch("clamav_scanner.scan.update_defs_from_s3")
+@patch("api_gateway.routers.clamav.get_db_session")
+def test_clamav_start_scan_with_arn(
+    mock_db_session,
+    mock_update_defs_from_s3,
+    mock_sns_scan_results,
+    mock_aws_session,
+    mock_scan_file,
+    mock_s3_download,
+    session,
+):
+    create_dir(
+        "/tmp/clamav/quarantine"  # nosec - [B108:hardcoded_tmp_directory] no risk in tests
+    )
+    filename = "tests/api_gateway/fixtures/file.txt"
+
+    mock_update_defs_from_s3.return_value.values.return_value = [mock_s3_download]
+
+    mock_scan_file.return_value = (
+        AV_STATUS_CLEAN,
+        AV_SIGNATURE_OK,
+        "/foo/bar/file.txt",
+    )
+
+    client.post(
+        "/clamav",
+        data={
+            "sns_arn": "arn:aws:sns:us-east-1:123456789012:sns-topic",
+        },
+        files={"file": ("random_file", open(filename, "rb"), "text/plain")},
+        headers={"Authorization": os.environ["API_AUTH_TOKEN"]},
+    )
+
+    mock_sns_scan_results.assert_called_once_with(
+        ANY, ANY, "arn:aws:sns:us-east-1:123456789012:sns-topic", "OK", ANY
+    )
+
+
+@patch("api_gateway.routers.clamav.launch_scan")
+@patch("api_gateway.routers.clamav.get_db_session")
+def test_clamav_start_scan_with_exception(mock_db_session, mock_launch_scan):
+    create_dir(
+        "/tmp/clamav/quarantine"  # nosec - [B108:hardcoded_tmp_directory] no risk in tests
+    )
+    filename = "tests/api_gateway/fixtures/file.txt"
+
+    mock_launch_scan.side_effect = OSError
+
+    response = client.post(
+        "/clamav",
+        files={"file": ("random_file", open(filename, "rb"), "text/plain")},
+        headers={"Authorization": os.environ["API_AUTH_TOKEN"]},
+    )
+
+    assert response.json() == {"error": "error scanning file [random_file] with clamav"}
+    assert response.status_code == 502
+
+
+@patch("clamav_scanner.clamav.get_file")
+@patch("clamav_scanner.clamav.subprocess")
+@patch("clamav_scanner.scan.update_defs_from_s3")
+@patch("clamav_scanner.scan.get_session")
+@patch("api_gateway.routers.clamav.get_db_session")
+def test_clamav_start_scan_from_s3(
+    mock_db_session,
+    mock_aws_session,
+    mock_update_defs_from_s3,
+    mock_subprocess,
+    mock_get_file,
+    mock_s3_download,
+    session,
+):
+    create_dir(
+        "/tmp/clamav/quarantine"  # nosec - [B108:hardcoded_tmp_directory] no risk in tests
+    )
+
+    mock_update_defs_from_s3.return_value.values.return_value = [mock_s3_download]
+    mock_subprocess.run.return_value.returncode = 0
+    mock_subprocess.run.return_value.stdout = "scan complete".encode("utf-8")
+
+    file = TemporaryFile()
+    mock_get_file.return_value = file
+
+    client.post(
+        "/clamav/s3",
+        json={
+            "s3_key": "s3://bucket/file.txt",
+            "sns_arn": "arn:aws:sns:us-east-1:123456789012:sns-topic",
+        },
+        headers={"Authorization": os.environ["API_AUTH_TOKEN"]},
+    )
+
+    mock_get_file.assert_called_once_with("s3://bucket/file.txt")
+
+
+@patch("clamav_scanner.clamav.get_file")
+@patch("clamav_scanner.clamav.subprocess")
+@patch("clamav_scanner.scan.update_defs_from_s3")
+@patch("clamav_scanner.scan.get_session")
+@patch("api_gateway.routers.clamav.get_db_session")
+def test_clamav_start_scan_with_s3_and_exception(
+    mock_db_session,
+    mock_aws_session,
+    mock_update_defs_from_s3,
+    mock_subprocess,
+    mock_get_file,
+    mock_s3_download,
+    session,
+):
+    create_dir(
+        "/tmp/clamav/quarantine"  # nosec - [B108:hardcoded_tmp_directory] no risk in tests
+    )
+
+    mock_update_defs_from_s3.return_value.values.return_value = [mock_s3_download]
+    mock_subprocess.run.return_value.returncode = 0
+    mock_subprocess.run.return_value.stdout = "scan complete".encode("utf-8")
+
+    mock_get_file.side_effect = Exception("error")
+    response = client.post(
+        "/clamav/s3",
+        json={
+            "s3_key": "s3://bucket/file.txt",
+            "sns_arn": "arn:aws:sns:us-east-1:123456789012:sns-topic",
+        },
+        headers={"Authorization": os.environ["API_AUTH_TOKEN"]},
+    )
+
+    assert response.json() == {"scan_id": ANY, "status": "OK"}
+
+    scan_id = response.json()["scan_id"]
+    updated_scan = session.query(Scan).filter(Scan.id == scan_id).one_or_none()
+    assert updated_scan.verdict == ScanVerdicts.ERROR.value
+    assert updated_scan.meta_data == {
+        "av-signature": "UNKNOWN",
+        "ERROR": "Error retrieving file: [s3://bucket/file.txt] from s3. Reason: error.\n",
+    }
+    assert response.status_code == 200
 
 
 @patch("api_gateway.routers.clamav.get_db_session")

--- a/api/tests/clamav/test_scan.py
+++ b/api/tests/clamav/test_scan.py
@@ -1,6 +1,5 @@
 from unittest.mock import patch, ANY, MagicMock
-from clamav_scanner.common import AV_SIGNATURE_OK
-from clamav_scanner.common import AV_STATUS_CLEAN
+from clamav_scanner.common import AV_SIGNATURE_OK, AV_STATUS_CLEAN
 from clamav_scanner.scan import launch_scan, sns_scan_results
 from factories import ScanFactory
 from models.Scan import ScanVerdicts
@@ -17,19 +16,18 @@ def test_clamav_scan(
     mock_update_defs_from_s3,
     mock_scan_file,
     mock_sns_scan_results,
+    mock_s3_download,
     session,
 ):
     scan = ScanFactory(verdict=ScanVerdicts.IN_PROGRESS.value, meta_data={"sid": "123"})
     session.commit()
 
-    download = {}
-    download["s3_path"] = "s3://bucket/prefix/definitions.json"
-    download[
-        "local_path"
-    ] = "/tmp/definitions.json"  # nosec - [B108:hardcoded_tmp_directory] no risk in tests
-
-    mock_update_defs_from_s3.return_value.values.return_value = [download]
-    mock_scan_file.return_value = (AV_STATUS_CLEAN, AV_SIGNATURE_OK)
+    mock_update_defs_from_s3.return_value.values.return_value = [mock_s3_download]
+    mock_scan_file.return_value = (
+        AV_STATUS_CLEAN,
+        AV_SIGNATURE_OK,
+        "/foo/bar/file.txt",
+    )
     scan_verdict = launch_scan(
         "/tmp/foo",  # nosec - [B108:hardcoded_tmp_directory] no risk in tests
         scan.id,
@@ -37,8 +35,8 @@ def test_clamav_scan(
     )
 
     mock_aws_session().resource().Bucket().download_file.assert_called_once_with(
-        download["s3_path"],
-        download["local_path"],
+        mock_s3_download["s3_path"],
+        mock_s3_download["local_path"],
     )
 
     assert scan_verdict == ScanVerdicts.CLEAN.value
@@ -57,12 +55,14 @@ def test_sns_scan_results(mock_db_session, mock_aws_session, session):
         scan,
         "arn:aws:sns:ca-central-1:000000000000:clamav_scan-topic",
         AV_SIGNATURE_OK,
+        "/foo/bar/file.txt",
     )
     mock_sns_client.publish.assert_called_once_with(
         TargetArn="arn:aws:sns:ca-central-1:000000000000:clamav_scan-topic",
         Message=ANY,
         MessageStructure="json",
         MessageAttributes={
+            "av-filepath": {"DataType": "String", "StringValue": "/foo/bar/file.txt"},
             "av-status": {"DataType": "String", "StringValue": "clean"},
             "av-signature": {"DataType": "String", "StringValue": "OK"},
         },

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -72,3 +72,14 @@ def hsts_middleware_client():
     app.include_router(ops.router)
     client = TestClient(app)
     yield client
+
+
+@pytest.fixture
+def mock_s3_download():
+    download = {}
+    download["s3_path"] = "s3://bucket/prefix/definitions.json"
+    download[
+        "local_path"
+    ] = "/tmp/definitions.json"  # nosec - [B108:hardcoded_tmp_directory] no risk in tests
+
+    return download


### PR DESCRIPTION
New endpoint that accepts a s3 object key & sns arn. The scan-files role `arn:aws:iam::806545929748:role/api` will need s3 get permissions.

![image](https://user-images.githubusercontent.com/85885638/174490547-69d4df91-866f-4846-9fd0-935cb0ef6bc1.png)
