### PR TITLE
feat: store the api key in ssm to be shared

### DIFF
--- a/.github/workflows/tf_apply.yml
+++ b/.github/workflows/tf_apply.yml
@@ -8,11 +8,8 @@ on:
 env:
   TERRAFORM_VERSION: 1.0.3
   TERRAGRUNT_VERSION: v0.31.1
-  TF_VAR_fastapi_secret_key: ${{ secrets.TF_VARS_FASTAPI_SECRET_KEY }}
-  TF_VAR_mlwr_host: ${{ secrets.MLWR_HOST }}
-  TF_VAR_mlwr_user: ${{ secrets.MLWR_USER }}
-  TF_VAR_mlwr_key: ${{ secrets.MLWR_KEY }}
   TF_VAR_api_auth_token: ${{ secrets.TF_VARS_API_AUTH_TOKEN }}
+  TF_VAR_aws_org_id: ${{ secrets.TF_VARS_AWS_ORG_ID }}
   TF_VAR_rds_password: ${{ secrets.TF_VARS_RDS_PASSWORD }}
   AWS_REGION: ca-central-1
 

--- a/.github/workflows/tf_plan.yml
+++ b/.github/workflows/tf_plan.yml
@@ -10,11 +10,8 @@ env:
   TERRAFORM_VERSION: 1.0.3
   TERRAGRUNT_VERSION: v0.31.1
   CONFTEST_VERSION: 0.27.0
-  TF_VAR_fastapi_secret_key: ${{ secrets.TF_VARS_FASTAPI_SECRET_KEY }}
-  TF_VAR_mlwr_host: ${{ secrets.MLWR_HOST }}
-  TF_VAR_mlwr_user: ${{ secrets.MLWR_USER }}
-  TF_VAR_mlwr_key: ${{ secrets.MLWR_KEY }}
   TF_VAR_api_auth_token: ${{ secrets.TF_VARS_API_AUTH_TOKEN }}
+  TF_VAR_aws_org_id: ${{ secrets.TF_VARS_AWS_ORG_ID }}
   TF_VAR_rds_password: ${{ secrets.TF_VARS_RDS_PASSWORD }}
 
 permissions:

--- a/api/bin/entry.sh
+++ b/api/bin/entry.sh
@@ -42,6 +42,11 @@ else
         mkdir "$ENV_PATH"
       fi
       aws ssm get-parameters --region ca-central-1 --with-decryption --names ENVIRONMENT_VARIABLES --query 'Parameters[*].Value' --output text > "$TMP_ENV_FILE"
+      if [ -z "${API_AUTH_TOKEN_SSM_NAME}" ]; then
+        echo "API_AUTH_TOKEN_SSM_NAME is not set"
+      else
+        aws ssm get-parameters --region ca-central-1 --with-decryption --names "$API_AUTH_TOKEN_SSM_NAME" --query 'Parameters[*].Value' --output text >> "$TMP_ENV_FILE"
+      fi
     fi
     load_non_existing_envs
 

--- a/terragrunt/aws/api/iam.tf
+++ b/terragrunt/aws/api/iam.tf
@@ -125,7 +125,8 @@ data "aws_iam_policy_document" "api_policies" {
       "ssm:GetParameters",
     ]
     resources = [
-      "arn:aws:ssm:${var.region}:${var.account_id}:parameter/ENVIRONMENT_VARIABLES"
+      "arn:aws:ssm:${var.region}:${var.account_id}:parameter/ENVIRONMENT_VARIABLES",
+      aws_ssm_parameter.api_auth_token.arn
     ]
   }
 }

--- a/terragrunt/aws/api/inputs.tf
+++ b/terragrunt/aws/api/inputs.tf
@@ -3,21 +3,6 @@ variable "api_auth_token" {
   sensitive = true
 }
 
-variable "mlwr_host" {
-  type      = string
-  sensitive = true
-}
-
-variable "mlwr_user" {
-  type      = string
-  sensitive = true
-}
-
-variable "mlwr_key" {
-  type      = string
-  sensitive = true
-}
-
 variable "rds_password" {
   type      = string
   sensitive = true

--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -18,6 +18,7 @@ module "api" {
   environment_variables = {
     SQLALCHEMY_DATABASE_URI = module.rds.proxy_connection_string_value
     FILE_QUEUE_BUCKET       = module.file-queue.s3_bucket_id
+    API_AUTH_TOKEN          = var.api_auth_token
   }
 
   policies = [

--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -18,7 +18,7 @@ module "api" {
   environment_variables = {
     SQLALCHEMY_DATABASE_URI = module.rds.proxy_connection_string_value
     FILE_QUEUE_BUCKET       = module.file-queue.s3_bucket_id
-    API_AUTH_TOKEN          = var.api_auth_token
+    API_AUTH_TOKEN_SSM_NAME = aws_ssm_parameter.api_auth_token.name
   }
 
   policies = [

--- a/terragrunt/aws/api/ssm.tf
+++ b/terragrunt/aws/api/ssm.tf
@@ -1,0 +1,11 @@
+resource "aws_ssm_parameter" "api_auth_token" {
+  #checkov:skip=CKV2_AWS_34:Encryption: Not required
+  name  = "/scan-files/api_auth_token"
+  type  = "SecureString"
+  value = var.api_auth_token
+
+  tags = {
+    CostCentre = var.billing_code
+    Terraform  = true
+  }
+}


### PR DESCRIPTION
Cleanup of items moved to the `ENVIRONMENT_VARIABLE` ssm paramter as well as creating a new parameter to be used to share the api key amongst scan-files services that need it.