### PR TITLE
chore: remove unused scan-files-api IAM role

### DIFF
--- a/.github/workflows/scripts/migrate.sh
+++ b/.github/workflows/scripts/migrate.sh
@@ -14,7 +14,7 @@ function test_migrate_resp {
 
 function migrate {
   aws lambda get-function \
-    --function-name api \
+    --function-name scan-files-api \
     --region ca-central-1 \
     --query 'Configuration.[State, LastUpdateStatus]' > status
 
@@ -28,14 +28,14 @@ function migrate {
     fi
     sleep 10
     aws lambda get-function \
-      --function-name api \
+      --function-name scan-files-api \
       --region ca-central-1 \
       --query 'Configuration.[State, LastUpdateStatus]' > status
     COUNTER=$((COUNTER+1))
   done
 
   aws lambda invoke \
-    --function-name api \
+    --function-name scan-files-api \
     --cli-binary-format raw-in-base64-out \
     --payload '{ "task": "migrate" }' \
     --region ca-central-1 \

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -34,7 +34,7 @@ def assert_new_model_saved():
 @pytest.fixture
 def context_fixture():
     context = MagicMock()
-    context.function_name = "api"
+    context.function_name = "scan-files-api"
     return context
 
 

--- a/api/tests/test_main.py
+++ b/api/tests/test_main.py
@@ -19,7 +19,7 @@ def test_handler_api_gateway_event(mock_mangum, context_fixture, capsys):
         "ColdStart"
         in metrics_output["_aws"]["CloudWatchMetrics"][0]["Metrics"][0]["Name"]
     )
-    assert metrics_output["function_name"] == "api"
+    assert metrics_output["function_name"] == "scan-files-api"
 
 
 @patch("main.log")

--- a/terragrunt/aws/api/iam.tf
+++ b/terragrunt/aws/api/iam.tf
@@ -1,26 +1,3 @@
-data "aws_iam_policy_document" "service_principal" {
-  statement {
-    effect = "Allow"
-
-    actions = ["sts:AssumeRole"]
-
-    principals {
-      type        = "Service"
-      identifiers = ["lambda.amazonaws.com"]
-    }
-  }
-}
-
-resource "aws_iam_role" "api" {
-  name               = "${var.product_name}-api"
-  assume_role_policy = data.aws_iam_policy_document.service_principal.json
-
-  tags = {
-    CostCentre = var.billing_code
-    Terraform  = true
-  }
-}
-
 data "aws_iam_policy_document" "api_policies" {
 
   statement {
@@ -131,22 +108,6 @@ data "aws_iam_policy_document" "api_policies" {
   }
 }
 
-resource "aws_iam_policy" "api" {
-  name   = "${var.product_name}-api"
-  path   = "/"
-  policy = data.aws_iam_policy_document.api_policies.json
-
-  tags = {
-    CostCentre = var.billing_code
-    Terraform  = true
-  }
-}
-
-resource "aws_iam_role_policy_attachment" "api" {
-  role       = aws_iam_role.api.name
-  policy_arn = aws_iam_policy.api.arn
-}
-
 #
 # Allow API to assume cross-account S3/SNS scan role
 #
@@ -165,22 +126,6 @@ data "aws_iam_policy_document" "api_assume_cross_account" {
       variable = "aws:PrincipalOrgID"
     }
   }
-}
-
-resource "aws_iam_policy" "api_assume_cross_account" {
-  name   = "${var.product_name}-api-assume-cross-account"
-  path   = "/"
-  policy = sensitive(data.aws_iam_policy_document.api_assume_cross_account.json)
-
-  tags = {
-    CostCentre = var.billing_code
-    Terraform  = true
-  }
-}
-
-resource "aws_iam_role_policy_attachment" "api_assume_cross_account" {
-  role       = aws_iam_role.api.name
-  policy_arn = aws_iam_policy.api_assume_cross_account.arn
 }
 
 resource "aws_iam_role" "waf_log_role" {

--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -1,6 +1,6 @@
 module "api" {
   source                   = "github.com/cds-snc/terraform-modules?ref=v0.0.45//lambda"
-  name                     = "api"
+  name                     = "${var.product_name}-api"
   billing_tag_value        = var.billing_code
   allow_api_gateway_invoke = true
   api_gateway_source_arn   = "${aws_api_gateway_rest_api.api.execution_arn}/*/*"

--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -23,6 +23,7 @@ module "api" {
 
   policies = [
     data.aws_iam_policy_document.api_policies.json,
+    sensitive(data.aws_iam_policy_document.api_assume_cross_account.json)
   ]
 }
 


### PR DESCRIPTION
# Summary
The Lambda function is using an IAM role it creates and manages
as part of the module. This change removes the unused IAM role 
and attaches the cross-account assume policy
to the Lambda function.

Also renames the Lambda function from `api` to `scan-files-api`.