### PR TITLE
fix: cause API gateway redeploy and update workflow

### DIFF
--- a/.github/workflows/build_and_push_production.yml
+++ b/.github/workflows/build_and_push_production.yml
@@ -76,7 +76,7 @@ jobs:
         if: matrix.image == 'api'
         run: |
           aws lambda update-function-code \
-            --function-name ${{ matrix.image }} \
+            --function-name scan-files-api \
             --image-uri $REGISTRY/${{ matrix.image }}:latest  > /dev/null 2>&1
 
       - name: Migrate Database

--- a/terragrunt/aws/api/api_gateway.tf
+++ b/terragrunt/aws/api/api_gateway.tf
@@ -32,6 +32,7 @@ resource "aws_api_gateway_base_path_mapping" "api" {
   stage_name  = aws_api_gateway_stage.api.stage_name
   domain_name = aws_api_gateway_domain_name.api.domain_name
 }
+
 resource "aws_api_gateway_resource" "resource" {
   rest_api_id = aws_api_gateway_rest_api.api.id
   parent_id   = aws_api_gateway_rest_api.api.root_resource_id
@@ -101,7 +102,7 @@ resource "aws_api_gateway_integration_response" "integration_response" {
 
 resource "aws_api_gateway_deployment" "api" {
   rest_api_id       = aws_api_gateway_rest_api.api.id
-  stage_description = md5(file("api_gateway.tf"))
+  stage_description = join("|", [md5(file("api_gateway.tf")), md5(file("lambda.tf"))])
 
   lifecycle {
     create_before_destroy = true


### PR DESCRIPTION
# Summary 
Cause API gateway deployment to be recreated when there
are changes to the `lambda.tf` file as well.

Also updates the build/push container workflow with the
new lambda function name.

# Related
* #110 