### PR TITLE
fix: retrieve object ref instead of file

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -58,6 +58,7 @@ region=ca-central-1\n\
 output=json\n\
 " >> /home/vscode/.aws/config
 
+RUN chown -R vscode:vscode /home/vscode/.aws
 # [Optional] If your pip requirements rarely change, uncomment this section to add them to the image.
 # COPY requirements.txt /tmp/pip-tmp/
 # RUN pip3 --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \

--- a/api/clamav_scanner/clamav.py
+++ b/api/clamav_scanner/clamav.py
@@ -187,7 +187,7 @@ def scan_file(path, aws_account=None):
         try:
             save_path = f"{AV_DEFINITION_PATH}/quarantine/{str(uuid4())}"
             create_dir(f"{AV_DEFINITION_PATH}/quarantine")
-            file = get_file(path, aws_account=aws_account)
+            file = get_file(path, aws_account=aws_account, ref_only=True)
             with open(save_path, "wb") as file_on_disk:
                 file.seek(0)
                 file_on_disk.write(file.read())

--- a/api/clamav_scanner/scan.py
+++ b/api/clamav_scanner/scan.py
@@ -20,13 +20,14 @@ from models.Scan import Scan, ScanProviders, ScanVerdicts
 def sns_scan_results(sns_client, scan, sns_arn, scan_signature, file_path):
 
     message = {
-        "scan_id": scan.id,
+        "scan_id": str(scan.id),
         "file_path": file_path,
         AV_SIGNATURE_METADATA: scan_signature,
         AV_STATUS_METADATA: scan.verdict,
-        AV_TIMESTAMP_METADATA: scan.completed,
+        AV_TIMESTAMP_METADATA: scan.completed.isoformat(),
     }
 
+    log.info("Publishing to sns arn: %s; message: %s" % (sns_arn, str(message)))
     sns_client.publish(
         TargetArn=sns_arn,
         Message=json.dumps({"default": json.dumps(message, default=str)}),

--- a/api/tests/api_gateway/test_clamav_scans.py
+++ b/api/tests/api_gateway/test_clamav_scans.py
@@ -175,7 +175,7 @@ def test_clamav_start_scan_from_s3(
     )
 
     mock_get_file.assert_called_once_with(
-        "s3://bucket/file.txt", aws_account=mock_account_id
+        "s3://bucket/file.txt", aws_account=mock_account_id, ref_only=True
     )
 
     assert response.status_code == 200

--- a/api/tests/clamav/test_scan.py
+++ b/api/tests/clamav/test_scan.py
@@ -47,7 +47,7 @@ def test_clamav_scan(
 @patch("clamav_scanner.scan.get_session")
 @patch("clamav_scanner.scan.get_db_session")
 def test_sns_scan_results(mock_db_session, mock_aws_session, session):
-    scan = ScanFactory(verdict=ScanVerdicts.CLEAN.value, meta_data={"sid": "123"})
+    scan = ScanFactory(verdict=ScanVerdicts.CLEAN.value, meta_data={"sid": "123"}, completed="2021-12-12T17:20:03.930469Z")
     session.commit()
     mock_sns_client = MagicMock()
     sns_scan_results(

--- a/api/tests/clamav/test_scan.py
+++ b/api/tests/clamav/test_scan.py
@@ -47,7 +47,11 @@ def test_clamav_scan(
 @patch("clamav_scanner.scan.get_session")
 @patch("clamav_scanner.scan.get_db_session")
 def test_sns_scan_results(mock_db_session, mock_aws_session, session):
-    scan = ScanFactory(verdict=ScanVerdicts.CLEAN.value, meta_data={"sid": "123"}, completed="2021-12-12T17:20:03.930469Z")
+    scan = ScanFactory(
+        verdict=ScanVerdicts.CLEAN.value,
+        meta_data={"sid": "123"},
+        completed="2021-12-12T17:20:03.930469Z",
+    )
     session.commit()
     mock_sns_client = MagicMock()
     sns_scan_results(


### PR DESCRIPTION
Fix to only retrieve a file reference so that the file can be seek+read when writing to disk.