### PR TITLE
feat: S3 scan object ECR for Lambda container image

### DIFF
--- a/.github/workflows/tf_apply_production.yml
+++ b/.github/workflows/tf_apply_production.yml
@@ -1,9 +1,12 @@
-name: "Terraform"
+name: "Terraform apply production"
 
 on:
   push:
     branches:
       - main
+    paths:
+      - "terragrunt/**"
+      - ".github/workflows/tf_apply_production.yml"      
 
 env:
   TERRAFORM_VERSION: 1.0.3
@@ -29,18 +32,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@17d4c9b8043b238f6f35641cdd8433da1e6f3867 # renovate: tag=v2.0.0
-        with:
-          terraform_version: ${{ env.TERRAFORM_VERSION }}
-          terraform_wrapper: false
-
-      - name: Setup Terragrunt
-        run: |
-          mkdir -p bin
-          wget -O bin/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/$TERRAGRUNT_VERSION/terragrunt_linux_amd64
-          chmod +x bin/terragrunt
-          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
+      - name: setup terraform tools
+        uses: cds-snc/terraform-tools-setup@v1
 
       - uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721 # tag=v2.10.2
         id: filter
@@ -51,7 +44,10 @@ jobs:
               - 'terragrunt/env/production/api/**'
             hosted_zone:
               - 'terragrunt/aws/hosted_zone/**'
-              - 'terragrunt/env/production/hosted_zone/**'              
+              - 'terragrunt/env/production/hosted_zone/**'
+            s3_scan_object:
+              - 'terragrunt/aws/s3_scan_object/**'
+              - 'terragrunt/env/production/s3_scan_object/**'                           
             scan_queue:
               - 'terragrunt/aws/scan_queue/**'
               - 'terragrunt/env/production/scan_queue/**'
@@ -75,8 +71,14 @@ jobs:
         run: |
           terragrunt apply --terragrunt-non-interactive -auto-approve
 
+      - name: Apply s3_scan_object
+        if: ${{ steps.filter.outputs.s3_scan_object == 'true' }}
+        working-directory: terragrunt/env/production/s3_scan_object
+        run: |
+          terragrunt apply --terragrunt-non-interactive -auto-approve 
+
       - name: Apply scan_queue
         if: ${{ steps.filter.outputs.scan_queue == 'true' }}
         working-directory: terragrunt/env/production/scan_queue
         run: |
-          terragrunt apply --terragrunt-non-interactive -auto-approve
+          terragrunt apply --terragrunt-non-interactive -auto-approve         

--- a/.github/workflows/tf_apply_production.yml
+++ b/.github/workflows/tf_apply_production.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   TERRAFORM_VERSION: 1.0.3
-  TERRAGRUNT_VERSION: v0.31.1
+  TERRAGRUNT_VERSION: 0.31.1
   TF_VAR_api_auth_token: ${{ secrets.PRODUCTION_API_AUTH_TOKEN }}
   TF_VAR_aws_org_id: ${{ secrets.AWS_ORG_ID }}
   TF_VAR_rds_password: ${{ secrets.PRODUCTION_RDS_PASSWORD }}

--- a/.github/workflows/tf_plan_production.yml
+++ b/.github/workflows/tf_plan_production.yml
@@ -8,7 +8,7 @@ on:
 env:
   AWS_REGION: ca-central-1
   TERRAFORM_VERSION: 1.0.3
-  TERRAGRUNT_VERSION: v0.31.1
+  TERRAGRUNT_VERSION: 0.31.1
   CONFTEST_VERSION: 0.27.0
   TF_VAR_api_auth_token: ${{ secrets.PRODUCTION_API_AUTH_TOKEN }}
   TF_VAR_aws_org_id: ${{ secrets.AWS_ORG_ID }}

--- a/.github/workflows/tf_plan_production.yml
+++ b/.github/workflows/tf_plan_production.yml
@@ -1,10 +1,10 @@
-name: Terraform plan
+name: "Terraform plan production"
 on:
   workflow_dispatch:
   pull_request:
     paths:
       - "terragrunt/**"
-      - ".github/workflows/**"
+      - ".github/workflows/tf_plan_production.yml"
 env:
   AWS_REGION: ca-central-1
   TERRAFORM_VERSION: 1.0.3
@@ -30,6 +30,7 @@ jobs:
         include:
           - module: api
           - module: hosted_zone
+          - module: s3_scan_object
           - module: scan_queue
 
     runs-on: ubuntu-latest
@@ -37,27 +38,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
 
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@17d4c9b8043b238f6f35641cdd8433da1e6f3867 # renovate: tag=v2.0.0
-        with:
-          terraform_version: ${{ env.TERRAFORM_VERSION }}
-          terraform_wrapper: false
-
-      - name: Setup Terragrunt
-        run: |
-          mkdir -p bin
-          wget -O bin/terragrunt https://github.com/gruntwork-io/terragrunt/releases/download/$TERRAGRUNT_VERSION/terragrunt_linux_amd64
-          chmod +x bin/*
-          echo "$GITHUB_WORKSPACE/bin" >> $GITHUB_PATH
-
-      - name: Install Conftest
-        run: |
-          wget "https://github.com/open-policy-agent/conftest/releases/download/v${{ env.CONFTEST_VERSION }}/conftest_${{ env.CONFTEST_VERSION }}_Linux_x86_64.tar.gz" \
-          && wget "https://github.com/open-policy-agent/conftest/releases/download/v${{ env.CONFTEST_VERSION }}/checksums.txt" \
-          && grep 'Linux_x86_64.tar.gz' < checksums.txt | sha256sum --check  --status \
-          && tar -zxvf "conftest_${{ env.CONFTEST_VERSION }}_Linux_x86_64.tar.gz" conftest \
-          && mv conftest /usr/local/bin \
-          && rm "conftest_${{ env.CONFTEST_VERSION }}_Linux_x86_64.tar.gz" checksums.txt
+      - name: setup terraform tools
+        uses: cds-snc/terraform-tools-setup@v1
 
       - name: configure aws credentials using OIDC
         uses: aws-actions/configure-aws-credentials@05b148adc31e091bafbaf404f745055d4d3bc9d2 # tag=v1.6.1

--- a/terragrunt/aws/s3_scan_object/ecr.tf
+++ b/terragrunt/aws/s3_scan_object/ecr.tf
@@ -1,0 +1,69 @@
+#
+# S3 object scan lambda Docker image
+#
+resource "aws_ecr_repository" "s3_scan_object" {
+  name                 = "s3-scan-object"
+  image_tag_mutability = "MUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+    Terraform             = "true"
+  }
+}
+
+#
+# Allow the lambda service in the same organization
+# to pull the Docker image
+#
+resource "aws_ecr_repository_policy" "s3_scan_object" {
+  repository = aws_ecr_repository.s3_scan_object.name
+  policy     = sensitive(data.aws_iam_policy_document.s3_scan_object.json)
+}
+
+data "aws_iam_policy_document" "s3_scan_object" {
+  statement {
+    sid    = "AllowLambdaPull"
+    effect = "Allow"
+
+    actions = [
+      "ecr:BatchGetImage",
+      "ecr:GetDownloadUrlForLayer"
+    ]
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringEquals"
+      values   = [var.aws_org_id]
+      variable = "aws:PrincipalOrgID"
+    }
+  }
+}
+
+resource "aws_ecr_lifecycle_policy" "s3_scan_object_exire_untagged" {
+  repository = aws_ecr_repository.s3_scan_object.name
+  policy = jsonencode({
+    "rules" : [
+      {
+        "rulePriority" : 1,
+        "description" : "Expire untagged images older than 14 days",
+        "selection" : {
+          "tagStatus" : "untagged",
+          "countType" : "sinceImagePushed",
+          "countUnit" : "days",
+          "countNumber" : 14
+        },
+        "action" : {
+          "type" : "expire"
+        }
+      }
+    ]
+  })
+}

--- a/terragrunt/aws/s3_scan_object/ecr.tf
+++ b/terragrunt/aws/s3_scan_object/ecr.tf
@@ -10,8 +10,8 @@ resource "aws_ecr_repository" "s3_scan_object" {
   }
 
   tags = {
-    (var.billing_tag_key) = var.billing_tag_value
-    Terraform             = "true"
+    CostCentre = var.billing_code
+    Terraform  = "true"
   }
 }
 

--- a/terragrunt/aws/scan_queue/inputs.tf
+++ b/terragrunt/aws/scan_queue/inputs.tf
@@ -1,31 +1,35 @@
 variable "concurrent_scan_limit" {
-  type        = number
   description = "The maximum number of ongoing scans"
+  type        = number
 }
 
 variable "retry_interval_seconds" {
-  type        = number
   description = "The number of seconds to wait before polling for results"
+  type        = number
 }
 
 variable "api_function_arn" {
-  type = string
+  default = "ARN of the API function"
+  type    = string
 }
 
 variable "api_function_name" {
-  type = string
+  default = "Name of the API function"
+  type    = string
 }
 
 variable "locktable_name" {
-  type        = string
   description = "Scan queue lock semaphore Dynamodb table name"
+  type        = string
 }
 
 variable "completed_scans_table_name" {
-  type = string
+  description = "Complete scan Dynamodb table name"
+  type        = string
 }
 
 variable "scan_queue_statemachine_name" {
-  type = string
+  description = "Name of the scan queue state machine"
+  type        = string
 }
 

--- a/terragrunt/env/production/s3_scan_object/terragrunt.hcl
+++ b/terragrunt/env/production/s3_scan_object/terragrunt.hcl
@@ -1,0 +1,7 @@
+terraform {
+  source = "../../../aws//s3_scan_object"
+}
+
+include {
+  path = find_in_parent_folders()
+}


### PR DESCRIPTION
# Summary
The Scan Files AWS account will hold the S3 scan object Lambda container
image in its shared ECR and allow other the Lambda service in other
AWS accounts in the same org to pull and use that image.

This PR creates the ECR and policy to allow the cross-account service access.

# Related
* cds-snc/forms-terraform#219