### PR TITLE
fix: S3 scan object ECR name

### DIFF
--- a/terragrunt/aws/s3_scan_object/ecr.tf
+++ b/terragrunt/aws/s3_scan_object/ecr.tf
@@ -2,7 +2,7 @@
 # S3 object scan lambda Docker image
 #
 resource "aws_ecr_repository" "s3_scan_object" {
-  name                 = "${var.product_name}/s3-scan-object"
+  name                 = "${var.product_name}/module/s3-scan-object"
   image_tag_mutability = "MUTABLE"
 
   image_scanning_configuration {


### PR DESCRIPTION
# Summary
Update the ECR name to include `module`.

# Related
* #122 
* cds-snc/forms-terraform#219