### PR TITLE
fix: allow suffixes on the S3 scan object name

### DIFF
--- a/terragrunt/aws/s3_scan_object/ecr.tf
+++ b/terragrunt/aws/s3_scan_object/ecr.tf
@@ -46,7 +46,7 @@ data "aws_iam_policy_document" "s3_scan_object" {
 
     condition {
       test     = "ArnLike"
-      values   = ["arn:aws:lambda:${var.region}:*:function:s3-scan-object"]
+      values   = ["arn:aws:lambda:${var.region}:*:function:s3-scan-object-*"]
       variable = "aws:SourceArn"
     }
   }


### PR DESCRIPTION
# Summary
The Terraform module adds the project name as a suffix to the
end of the function name.  This changes allows the creation
of those suffixed functions.

# ⚠️  Note
This was applied locally so there should be no plan changes.

# Related
* cds-snc/forms-terraform#219