### PR TITLE
fix: use domain name instead of bucket name

### DIFF
--- a/terragrunt/aws/api/cloudfront.tf
+++ b/terragrunt/aws/api/cloudfront.tf
@@ -41,7 +41,7 @@ resource "aws_cloudfront_distribution" "scan_files_api" {
 
   logging_config {
     include_cookies = false
-    bucket          = module.log_bucket.s3_bucket_id
+    bucket          = module.log_bucket.s3_bucket_domain_name
     prefix          = "cloudfront"
   }
 


### PR DESCRIPTION
cloudfront requires the domain name of the s3 bucket instead of it's name