### PR TITLE
fix: missing acm validation in us-east-1

### DIFF
--- a/terragrunt/aws/api/certificate.tf
+++ b/terragrunt/aws/api/certificate.tf
@@ -35,6 +35,7 @@ resource "aws_route53_record" "scan_files_dns_validation" {
 }
 
 resource "aws_acm_certificate_validation" "scan_files_certificate_validation" {
+  provider                = aws.us-east-1
   certificate_arn         = aws_acm_certificate.scan_files_certificate.arn
   validation_record_fqdns = [for record in aws_route53_record.scan_files_dns_validation : record.fqdn]
 }


### PR DESCRIPTION
One more missed item that needs to reside in us-east-1

![image](https://user-images.githubusercontent.com/85885638/176244440-f066695d-e076-4e9a-a326-9c0f51d8cb76.png)
