### PR TITLE
fix: use arn instead of id for waf

### DIFF
--- a/terragrunt/aws/api/cloudfront.tf
+++ b/terragrunt/aws/api/cloudfront.tf
@@ -1,7 +1,7 @@
 resource "aws_cloudfront_distribution" "scan_files_api" {
   enabled     = true
   price_class = "PriceClass_100"
-  web_acl_id  = aws_wafv2_web_acl.api_waf.id
+  web_acl_id  = aws_wafv2_web_acl.api_waf.arn
 
   origin {
     domain_name = split("/", aws_lambda_function_url.scan_files_url.function_url)[2]


### PR DESCRIPTION
wafv2 uses arn instead of id to associate with a cloudfront distribution