### PR TITLE
fix: add missing permission

### DIFF
--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -57,7 +57,7 @@ resource "aws_cloudwatch_event_target" "trigger_api_lambda_to_rescan" {
 # Update ClamAV virus database every 2 hours
 
 resource "aws_lambda_permission" "allow_cloudwatch_to_call_lambda_for_update_clamav" {
-  statement_id  = "AllowExecutionFromCloudWatch"
+  statement_id  = "AllowExecutionFromCloudWatchForVirusDefs"
   action        = "lambda:InvokeFunction"
   function_name = module.api.function_name
   principal     = "events.amazonaws.com"


### PR DESCRIPTION
ClamAV virus definitions were not being updated since the CloudWatch event didn't have permission to invoke the lambda.