### PR TITLE
feat: add ability to rescan existing S3 objects

### DIFF
--- a/module/s3-scan-object/app.test.js
+++ b/module/s3-scan-object/app.test.js
@@ -62,7 +62,7 @@ describe("handler", () => {
         {
           eventSource: "custom:rescan",
           s3ObjectUrl: "s3://boom/bing",
-        }
+        },
       ],
     };
     const expectedResponse = {
@@ -251,7 +251,7 @@ describe("getS3ObjectFromRecord", () => {
       Key: "gamgee",
     };
     expect(getS3ObjectFromRecord("custom:rescan", record)).toEqual(expected);
-  });  
+  });
 
   test("sns event, invalid av-filepath", () => {
     const record = {

--- a/module/s3-scan-object/app.test.js
+++ b/module/s3-scan-object/app.test.js
@@ -59,11 +59,15 @@ describe("handler", () => {
             },
           },
         },
+        {
+          eventSource: "custom:rescan",
+          s3ObjectUrl: "s3://boom/bing",
+        }
       ],
     };
     const expectedResponse = {
       status: 200,
-      body: "Event records processesed: 2, Errors: 0",
+      body: "Event records processesed: 3, Errors: 0",
     };
 
     axios.post.mockResolvedValue({ status: 200 });
@@ -190,6 +194,7 @@ describe("getRecordEventSource", () => {
   test("valid event sources", () => {
     expect(getRecordEventSource({ eventSource: "aws:s3" })).toBe("aws:s3");
     expect(getRecordEventSource({ EventSource: "aws:sns" })).toBe("aws:sns");
+    expect(getRecordEventSource({ eventSource: "custom:rescan" })).toBe("custom:rescan");
   });
 
   test("invalid event sources", () => {
@@ -236,6 +241,17 @@ describe("getS3ObjectFromRecord", () => {
     };
     expect(getS3ObjectFromRecord("aws:sns", record)).toEqual(expected);
   });
+
+  test("recan event", () => {
+    const record = {
+      s3ObjectUrl: "s3://samwise/gamgee",
+    };
+    const expected = {
+      Bucket: "samwise",
+      Key: "gamgee",
+    };
+    expect(getS3ObjectFromRecord("custom:rescan", record)).toEqual(expected);
+  });  
 
   test("sns event, invalid av-filepath", () => {
     const record = {


### PR DESCRIPTION
# Summary
Add a `custom:rescan` event source that allows the Lambda function
to retrigger a scan on an existing S3 object.  The expected event
payload is:

```javascript
{
    "Records": [{
        "eventSource": "custom:rescan",
        "s3ObjectUrl": "s3://bucket_name/object_key"
    }]
}
```

# Related
* Closes #141 
* cds-snc/forms-terraform#219