### PR TITLE
feat: send checksum back

### DIFF
--- a/api/clamav_scanner/scan.py
+++ b/api/clamav_scanner/scan.py
@@ -23,7 +23,7 @@ def sns_scan_results(sns_client, scan, sns_arn, scan_signature, file_path):
     message = {
         "scan_id": str(scan.id),
         "file_path": file_path,
-        "checksum": scan.checksum,
+        "checksum": scan.checksum if scan.checksum else "",
         AV_SIGNATURE_METADATA: scan_signature,
         AV_STATUS_METADATA: scan.verdict,
         AV_TIMESTAMP_METADATA: scan.completed.isoformat(),
@@ -36,7 +36,7 @@ def sns_scan_results(sns_client, scan, sns_arn, scan_signature, file_path):
         MessageStructure="json",
         MessageAttributes={
             "av-filepath": {"DataType": "String", "StringValue": file_path},
-            "av-checksum": {"DataType": "String", "StringValue": scan.checksum},
+            "av-checksum": {"DataType": "String", "StringValue": scan.checksum if scan.checksum else ""},
             AV_STATUS_METADATA: {"DataType": "String", "StringValue": scan.verdict},
             AV_SIGNATURE_METADATA: {
                 "DataType": "String",

--- a/api/clamav_scanner/scan.py
+++ b/api/clamav_scanner/scan.py
@@ -23,6 +23,7 @@ def sns_scan_results(sns_client, scan, sns_arn, scan_signature, file_path):
     message = {
         "scan_id": str(scan.id),
         "file_path": file_path,
+        "checksum": scan.checksum,
         AV_SIGNATURE_METADATA: scan_signature,
         AV_STATUS_METADATA: scan.verdict,
         AV_TIMESTAMP_METADATA: scan.completed.isoformat(),
@@ -35,6 +36,7 @@ def sns_scan_results(sns_client, scan, sns_arn, scan_signature, file_path):
         MessageStructure="json",
         MessageAttributes={
             "av-filepath": {"DataType": "String", "StringValue": file_path},
+            "av-checksum": {"DataType": "String", "StringValue": scan.checksum},
             AV_STATUS_METADATA: {"DataType": "String", "StringValue": scan.verdict},
             AV_SIGNATURE_METADATA: {
                 "DataType": "String",

--- a/api/clamav_scanner/scan.py
+++ b/api/clamav_scanner/scan.py
@@ -36,7 +36,10 @@ def sns_scan_results(sns_client, scan, sns_arn, scan_signature, file_path):
         MessageStructure="json",
         MessageAttributes={
             "av-filepath": {"DataType": "String", "StringValue": file_path},
-            "av-checksum": {"DataType": "String", "StringValue": scan.checksum if scan.checksum else ""},
+            "av-checksum": {
+                "DataType": "String",
+                "StringValue": scan.checksum if scan.checksum else "",
+            },
             AV_STATUS_METADATA: {"DataType": "String", "StringValue": scan.verdict},
             AV_SIGNATURE_METADATA: {
                 "DataType": "String",

--- a/api/tests/clamav/test_scan.py
+++ b/api/tests/clamav/test_scan.py
@@ -52,6 +52,7 @@ def test_sns_scan_results(mock_db_session, mock_aws_session, session):
         verdict=ScanVerdicts.CLEAN.value,
         meta_data={"sid": "123"},
         completed="2021-12-12T17:20:03.930469Z",
+        checksum="123"
     )
     session.commit()
     mock_sns_client = MagicMock()
@@ -68,6 +69,7 @@ def test_sns_scan_results(mock_db_session, mock_aws_session, session):
         MessageStructure="json",
         MessageAttributes={
             "av-filepath": {"DataType": "String", "StringValue": "/foo/bar/file.txt"},
+            "av-checksum": {"DataType": "String", "StringValue": "123"},
             "av-status": {"DataType": "String", "StringValue": "clean"},
             "av-signature": {"DataType": "String", "StringValue": "OK"},
         },

--- a/api/tests/clamav/test_scan.py
+++ b/api/tests/clamav/test_scan.py
@@ -52,7 +52,7 @@ def test_sns_scan_results(mock_db_session, mock_aws_session, session):
         verdict=ScanVerdicts.CLEAN.value,
         meta_data={"sid": "123"},
         completed="2021-12-12T17:20:03.930469Z",
-        checksum="123"
+        checksum="123",
     )
     session.commit()
     mock_sns_client = MagicMock()


### PR DESCRIPTION
the scan results sns topic will now receive the generated checksum in-order to offer non-repudiation that the scan verdict sent is the result of the file submitted for scanning.