### PR TITLE
feat: only keep 20 S3 scan object ECR images

### DIFF
--- a/module/s3-scan-object/README.md
+++ b/module/s3-scan-object/README.md
@@ -1,4 +1,4 @@
-# S3 scan object
+# S3 scan object :floppy_disk: :microscope:
 
 Lambda function that triggers a ClamAV scan of newly created S3 objects and updates the object with the scan results. The scan process and verdict is communicated via S3 object tags.
 
@@ -43,8 +43,8 @@ The infrastructure required can be built using the [S3_scan_object](https://gith
 ## Development
 
 ```sh
-yarn install       # Install dependencies
-yarn test          # Run unit tests (Jest)
-yarn lint          # Lint the code (eslint)
-yarn format:write  # Format the code (prettier)
+make install       # Install dependencies
+make test          # Run unit tests (Jest)
+make lint          # Lint the code (eslint)
+make fmt           # Format the code (prettier)
 ```

--- a/terragrunt/aws/s3_scan_object/ecr.tf
+++ b/terragrunt/aws/s3_scan_object/ecr.tf
@@ -90,6 +90,18 @@ resource "aws_ecr_lifecycle_policy" "s3_scan_object_exire_untagged" {
         "action" : {
           "type" : "expire"
         }
+      },
+      {
+        "rulePriority" : 2,
+        "description" : "Keep last 20 tagged images",
+        "selection" : {
+          "tagStatus" : "tagged",
+          "countType" : "imageCountMoreThan",
+          "countNumber" : 20
+        },
+        "action" : {
+          "type" : "expire"
+        }
       }
     ]
   })


### PR DESCRIPTION
# Summary
Add an ECR image policy to only keep the 20 most recently
tagged S3 scan object Docker images.  This will help save
us ECR storage costs.

Also, more importantly, adds emojis to the readme :floppy_disk: :microscope:

# Related
* cds-snc/forms-terraform#224