### PR TITLE
fix: S3 scan object ECR tag policy

### DIFF
--- a/terragrunt/aws/s3_scan_object/ecr.tf
+++ b/terragrunt/aws/s3_scan_object/ecr.tf
@@ -80,22 +80,9 @@ resource "aws_ecr_lifecycle_policy" "s3_scan_object_exire_untagged" {
     "rules" : [
       {
         "rulePriority" : 1,
-        "description" : "Expire untagged images older than 14 days",
+        "description" : "Keep last 20 images",
         "selection" : {
-          "tagStatus" : "untagged",
-          "countType" : "sinceImagePushed",
-          "countUnit" : "days",
-          "countNumber" : 14
-        },
-        "action" : {
-          "type" : "expire"
-        }
-      },
-      {
-        "rulePriority" : 2,
-        "description" : "Keep last 20 tagged images",
-        "selection" : {
-          "tagStatus" : "tagged",
+          "tagStatus" : "any",
           "countType" : "imageCountMoreThan",
           "countNumber" : 20
         },


### PR DESCRIPTION
# Summary
Update the ECR policy to only keep the latest 20 images.  This
simplifies things since there are never any untagged images in
the repository anyway.

# Related
* #147 
* cds-snc/forms-terraform#224