### PR TITLE
feat: toggleable ClamAV scan result caching

### DIFF
--- a/api/clamav_scanner/common.py
+++ b/api/clamav_scanner/common.py
@@ -9,6 +9,7 @@ AV_DEFINITION_PATH = os.getenv(
     "AV_DEFINITION_PATH",
     "/tmp/clamav",  # nosec - [B108:hardcoded_tmp_directory] Lambdas can only write to the /tmp folder
 )
+AV_SCAN_USE_CACHE = os.environ.get("AV_SCAN_USE_CACHE", True)
 AV_SCAN_START_SNS_ARN = os.getenv("AV_SCAN_START_SNS_ARN")
 AV_SCAN_START_METADATA = os.getenv("AV_SCAN_START_METADATA", "av-scan-start")
 AV_SIGNATURE_METADATA = os.getenv("AV_SIGNATURE_METADATA", "av-signature")

--- a/api/tests/clamav/test_clamav.py
+++ b/api/tests/clamav/test_clamav.py
@@ -294,8 +294,8 @@ def test_update_defs_from_s3_old_files(mock_exists, mock_md5_from_file):
         assert expected_to_download == to_download
 
 
-@patch("clamav_scanner.clamav.subprocess")
-def test_scan_file_already_scanned(mock_subprocess, session):
+@patch("clamav_scanner.clamav.subprocess.run")
+def test_scan_file_already_scanned(mock_subprocess_run, session):
     calculated_md5_hash = "118e0bb51e0f02e6f37937f4381b0318"
     current_time = datetime.datetime.utcnow()
     one_day_ago = (
@@ -319,4 +319,14 @@ def test_scan_file_already_scanned(mock_subprocess, session):
     assert scan_signature == AV_SIGNATURE_OK
     assert scanned_path == "tests/api_gateway/fixtures/file.txt"
 
-    assert mock_subprocess.call_count == 0
+    assert mock_subprocess_run.call_count == 0
+
+
+@patch(
+    "clamav_scanner.clamav.subprocess.run",
+    return_value=MagicMock(stdout=MagicMock(), returncode=0),
+)
+@patch("clamav_scanner.clamav.AV_SCAN_USE_CACHE", False)
+def test_scan_file_no_cache(mock_subprocess_run, session):
+    scan_file(session, "tests/api_gateway/fixtures/file.txt")
+    assert mock_subprocess_run.call_count == 1


### PR DESCRIPTION
# Summary
Add `AV_SCAN_USE_CACHE` environment variable that allows ClamAV
scan result caching to be disabled.  By default, caching will be enabled.

Use case is for performance testing so we can continually re-scan the
same set of files and trigger a full ClamAV subprocess scan.