### PR TITLE
fix: treat AV_SCAN_USE_CACHE env var as a boolean

### DIFF
--- a/api/clamav_scanner/common.py
+++ b/api/clamav_scanner/common.py
@@ -9,7 +9,7 @@ AV_DEFINITION_PATH = os.getenv(
     "AV_DEFINITION_PATH",
     "/tmp/clamav",  # nosec - [B108:hardcoded_tmp_directory] Lambdas can only write to the /tmp folder
 )
-AV_SCAN_USE_CACHE = os.environ.get("AV_SCAN_USE_CACHE", True)
+AV_SCAN_USE_CACHE = os.getenv("AV_SCAN_USE_CACHE", "True") in ("True", "true")
 AV_SCAN_START_SNS_ARN = os.getenv("AV_SCAN_START_SNS_ARN")
 AV_SCAN_START_METADATA = os.getenv("AV_SCAN_START_METADATA", "av-scan-start")
 AV_SIGNATURE_METADATA = os.getenv("AV_SIGNATURE_METADATA", "av-signature")


### PR DESCRIPTION
# Summary
Update how `AV_SCAN_USE_CACHE` environment variable is read so that
it is treated as a boolean value.