### PR TITLE
chore: bump API lambda memory to 1769 MB

### DIFF
--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -5,7 +5,7 @@ module "api" {
   ecr_arn                = aws_ecr_repository.api.arn
   enable_lambda_insights = true
   image_uri              = "${aws_ecr_repository.api.repository_url}:latest"
-  memory                 = 1536
+  memory                 = 1769
   timeout                = 300
 
   vpc = {


### PR DESCRIPTION
# Summary
Update the API Lambda function memory to 1,769 MB which is the memory
threshold that provides [1 vCPU to the function](https://docs.aws.amazon.com/lambda/latest/dg/configuration-function-common.html#configuration-memory-console).

During performance testing, this was the configuration that gave the
largest increase in speed compared to total memory allocated.

![1769MB-graph](https://user-images.githubusercontent.com/2110107/177203371-e6eecb24-2a4c-4f30-bd30-2c5a9581c27f.png)

![1769MB-data](https://user-images.githubusercontent.com/2110107/177203358-fb3a0506-e75e-4db2-908f-773d837ca53b.png)

