### PR TITLE
fix: generic scanning endpoint performance test

### DIFF
--- a/api/locustfile.py
+++ b/api/locustfile.py
@@ -20,6 +20,7 @@ def random_file():
 
 class APIUser(HttpUser):
     "Submit files for scanning"
+
     @task
     def run_flow(self):
         attach = random_file()

--- a/api/locustfile.py
+++ b/api/locustfile.py
@@ -1,10 +1,17 @@
+"""
+Performance testing for the scanning endpoints.  Creates
+a ramdom file and uploads it to the endpoint to trigger
+a scan.
+"""
 from locust import HttpUser, task
 import os
 import tempfile
 
+AV_ENDPOINT = os.environ.get("AV_ENDPOINT", "/clamav")
 
-# Generate random file
+
 def random_file():
+    "Generate random file"
     fout = tempfile.NamedTemporaryFile()
     fout.write(os.urandom(1024))
     fout.seek(0)
@@ -12,12 +19,13 @@ def random_file():
 
 
 class APIUser(HttpUser):
+    "Submit files for scanning"
     @task
     def run_flow(self):
         attach = random_file()
-        response = self.client.post("/assemblyline", files={"file": attach})
+        response = self.client.post(AV_ENDPOINT, files={"file": attach})
         results = response.json()
-        self.client.get(f"/assemblyline/{results['scan_id']}")
+        self.client.get(f"{AV_ENDPOINT}/{results['scan_id']}")
 
     def on_start(self):
         self.client.headers.update({"Authorization": os.environ.get("API_AUTH_TOKEN")})


### PR DESCRIPTION
# Summary
Update the Locust performance test to read from an `AV_ENDPOINT`
environment variable so that it can be used for Assemblyline and ClamAV
endpoint tests.

# Related
* cds-snc/platform-forms-client#853