### PR TITLE
feat: use clamav daemon to scan

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -11,7 +11,7 @@ x-api_envs: &api_envs
   AV_WRITE_PATH: "/tmp/clamav"
   AV_DEFINITION_S3_BUCKET: "clamav-defs"
   CLAMAVLIB_PATH: "/etc/clamav"
-  CLAMSCAN_PATH: "/usr/bin/clamscan"
+  CLAMDSCAN_PATH: "/usr/bin/clamscan"
   FRESHCLAM_PATH: "/usr/bin/freshclam"
 
 services:

--- a/api/.env.example
+++ b/api/.env.example
@@ -10,5 +10,5 @@ AV_DEFINITION_PATH=/clamav
 AV_WRITE_PATH=/tmp/clamav
 AV_DEFINITION_S3_BUCKET=
 CLAMAVLIB_PATH=/etc/clamav
-CLAMSCAN_PATH=/usr/bin/clamscan
+CLAMDSCAN_PATH=/usr/bin/clamdscan
 FRESHCLAM_PATH=/usr/bin/freshclam

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -6,7 +6,7 @@ FROM python:3.9-slim-buster
 RUN adduser --system --group python
 
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends ca-certificates curl git gstreamer1.0-libav libnss3-tools libatk-bridge2.0-0 libcups2-dev libxkbcommon-x11-0 libxcomposite-dev libxrandr2 libgbm-dev libgtk-3-0 libxshmfence-dev gnupg2 postgresql-client openssh-client python3-pip vim wget xz-utils zsh entr unzip clamav clamav-daemon \
+    && apt-get -y install --no-install-recommends ca-certificates curl git gstreamer1.0-libav libnss3-tools libatk-bridge2.0-0 libcups2-dev libxkbcommon-x11-0 libxcomposite-dev libxrandr2 libgbm-dev libgtk-3-0 libxshmfence-dev gnupg2 postgresql-client openssh-client python3-pip vim wget xz-utils zsh entr unzip clamav clamav-daemon clamdscan \
     && apt-get autoremove -y && apt-get clean -y
 
 # Include global arg in this stage of the build
@@ -57,13 +57,20 @@ RUN chown -R python:python ${FUNCTION_DIR}
 
 # Setup ClamAV
 RUN mkdir -p /clamav \
+ && mkdir -p /var/run/clamav \
  && mkdir -p /tmp/clamav/quarantine \
- && chown -R python:python /clamav /tmp/clamav /var/log/clamav \
+ && rmdir /var/lib/clamav \
+ && ln -s /clamav /var/lib \ 
+ && chown -R python:python /var/run/clamav /clamav /tmp/clamav /var/log/clamav \
  && mv clamav_defs/* /clamav \
  && rmdir clamav_defs \
  && sed -i 's/User clamav/User python/g' /etc/clamav/clamd.conf \
  && sed -i 's/CompressLocalDatabase no/CompressLocalDatabase yes/g' /etc/clamav/freshclam.conf \
  && sed -i 's/DatabaseOwner clamav/DatabaseOwner python/g' /etc/clamav/freshclam.conf \
+ && sed -i 's=LocalSocket /var/run/clamav/clamd.ctl=LocalSocket /tmp/clamd.sock=g' /etc/clamav/clamd.conf \ 
+ && sed -i 's=LocalSocketGroup clamav=LocalSocketGroup python=g' /etc/clamav/clamd.conf \
+ && sed -i 's=LocalSocketMode 666=LocalSocketMode 660=g' /etc/clamav/clamd.conf \ 
+ && echo "PidFile /tmp/clamd.pid" >> /etc/clamav/clamd.conf \ 
  && sed -i 's=UpdateLogFile /var/log/clamav/freshclam.log=UpdateLogFile /tmp/clamav/freshclam.log=g' /etc/clamav/freshclam.conf
 
 USER python

--- a/api/bin/entry.sh
+++ b/api/bin/entry.sh
@@ -4,6 +4,9 @@
 ENV_PATH="/tmp/scanfiles"
 TMP_ENV_FILE="$ENV_PATH/.env"
 
+# Start ClamAV daemon
+service clamav-daemon start
+
 var_expand() {
   if [ -z "${1-}" ] || [ $# -ne 1 ]; then
     printf 'var_expand: expected one argument\n' >&2;

--- a/api/clamav_scanner/clamav.py
+++ b/api/clamav_scanner/clamav.py
@@ -10,7 +10,6 @@ from pytz import utc
 
 from .common import AWS_ENDPOINT_URL
 from .common import AV_DEFINITION_S3_PREFIX
-from .common import AV_DEFINITION_PATH
 from .common import AV_WRITE_PATH
 from .common import AV_DEFINITION_FILE_PREFIXES
 from .common import AV_DEFINITION_FILE_SUFFIXES

--- a/api/clamav_scanner/clamav.py
+++ b/api/clamav_scanner/clamav.py
@@ -230,7 +230,14 @@ def scan_file(session, path, aws_account=None):
         )
     else:
         av_proc = subprocess.run(
-            [CLAMDSCAN_PATH, "-v", "--stdout", "--config-file", "%s/clamd.conf" % CLAMAVLIB_PATH, path],
+            [
+                CLAMDSCAN_PATH,
+                "-v",
+                "--stdout",
+                "--config-file",
+                "%s/clamd.conf" % CLAMAVLIB_PATH,
+                path,
+            ],
             stderr=subprocess.STDOUT,
             stdout=subprocess.PIPE,
             env=av_env,

--- a/api/clamav_scanner/clamav.py
+++ b/api/clamav_scanner/clamav.py
@@ -21,7 +21,7 @@ from .common import AV_SIGNATURE_METADATA
 from .common import AV_STATUS_CLEAN
 from .common import AV_STATUS_INFECTED
 from .common import CLAMAVLIB_PATH
-from .common import CLAMSCAN_PATH
+from .common import CLAMDSCAN_PATH
 from .common import FRESHCLAM_PATH
 from .common import create_dir
 
@@ -230,7 +230,7 @@ def scan_file(session, path, aws_account=None):
         )
     else:
         av_proc = subprocess.run(
-            [CLAMSCAN_PATH, "-v", "-a", "--stdout", "-d", AV_DEFINITION_PATH, path],
+            [CLAMDSCAN_PATH, "-v", "--stdout", "--config-file", "%s/clamd.conf" % CLAMAVLIB_PATH, path],
             stderr=subprocess.STDOUT,
             stdout=subprocess.PIPE,
             env=av_env,

--- a/api/clamav_scanner/common.py
+++ b/api/clamav_scanner/common.py
@@ -23,9 +23,9 @@ AV_STATUS_SNS_ARN = os.getenv("AV_STATUS_SNS_ARN")
 AV_STATUS_SNS_PUBLISH_CLEAN = os.getenv("AV_STATUS_SNS_PUBLISH_CLEAN", "True")
 AV_STATUS_SNS_PUBLISH_INFECTED = os.getenv("AV_STATUS_SNS_PUBLISH_INFECTED", "True")
 AV_TIMESTAMP_METADATA = os.getenv("AV_TIMESTAMP_METADATA", "av-timestamp")
-CLAMAVLIB_PATH = os.getenv("CLAMAVLIB_PATH", "./bin")
-CLAMSCAN_PATH = os.getenv("CLAMSCAN_PATH", "./bin/clamscan")
-FRESHCLAM_PATH = os.getenv("FRESHCLAM_PATH", "./bin/freshclam")
+CLAMAVLIB_PATH = os.getenv("CLAMAVLIB_PATH", "/etc/clamav")
+CLAMDSCAN_PATH = os.getenv("CLAMDSCAN_PATH", "/usr/bin/clamdscan")
+FRESHCLAM_PATH = os.getenv("FRESHCLAM_PATH", "/usr/bin/freshclam")
 AV_PROCESS_ORIGINAL_VERSION_ONLY = os.getenv(
     "AV_PROCESS_ORIGINAL_VERSION_ONLY", "False"
 )

--- a/terragrunt/aws/api/ecr.tf
+++ b/terragrunt/aws/api/ecr.tf
@@ -43,6 +43,7 @@ resource "aws_ecr_lifecycle_policy" "scan_files_exire_untagged" {
         "description" : "Keep last 20 tagged images",
         "selection" : {
           "tagStatus" : "tagged",
+          "tagPrefixList" : ["latest"],
           "countType" : "imageCountMoreThan",
           "countNumber" : 20
         },


### PR DESCRIPTION
The current ClamAV setup is taking ~30 seconds due to ClamAV loading the antivirus definitions in memory. We'll be migrating to use the daemon which will preload the definitions at the start of the container. This should significantly increase scan times since the majority of the 30 seconds was related to loading definitions into memory.