### PR TITLE
feat: Route53 health check to act as Lambda warmer

### DIFF
--- a/terragrunt/aws/api/cloudfront.tf
+++ b/terragrunt/aws/api/cloudfront.tf
@@ -18,6 +18,7 @@ resource "aws_cloudfront_distribution" "scan_files_api" {
   default_cache_behavior {
     allowed_methods = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
     cached_methods  = ["GET", "HEAD"]
+
     forwarded_values {
       query_string = true
       headers      = ["Authorization"]
@@ -29,6 +30,29 @@ resource "aws_cloudfront_distribution" "scan_files_api" {
     target_origin_id           = aws_lambda_function_url.scan_files_url.function_name
     viewer_protocol_policy     = "redirect-to-https"
     response_headers_policy_id = aws_cloudfront_response_headers_policy.security_headers_policy_api.id
+  }
+
+  # Prevent caching of healthcheck calls
+  ordered_cache_behavior {
+    path_pattern    = "/healthcheck"
+    allowed_methods = ["GET", "HEAD"]
+    cached_methods  = ["GET", "HEAD"]
+
+    forwarded_values {
+      query_string = true
+      cookies {
+        forward = "none"
+      }
+    }
+
+    target_origin_id           = aws_lambda_function_url.scan_files_url.function_name
+    viewer_protocol_policy     = "redirect-to-https"
+    response_headers_policy_id = aws_cloudfront_response_headers_policy.security_headers_policy_api.id
+
+    min_ttl     = 0
+    default_ttl = 0
+    max_ttl     = 0
+    compress    = true
   }
 
   restrictions {

--- a/terragrunt/aws/api/route53.tf
+++ b/terragrunt/aws/api/route53.tf
@@ -16,7 +16,7 @@ resource "aws_route53_health_check" "scan_files_A" {
   type              = "HTTPS"
   resource_path     = "/healthcheck"
   failure_threshold = "5"
-  request_interval  = "60"
+  request_interval  = "30"
 
   tags = {
     CostCentre = var.billing_code

--- a/terragrunt/aws/api/route53.tf
+++ b/terragrunt/aws/api/route53.tf
@@ -6,7 +6,7 @@ resource "aws_route53_record" "scan_files_A" {
   alias {
     name                   = aws_cloudfront_distribution.scan_files_api.domain_name
     zone_id                = aws_cloudfront_distribution.scan_files_api.hosted_zone_id
-    evaluate_target_health = true
+    evaluate_target_health = false
   }
 }
 

--- a/terragrunt/aws/api/route53.tf
+++ b/terragrunt/aws/api/route53.tf
@@ -6,6 +6,20 @@ resource "aws_route53_record" "scan_files_A" {
   alias {
     name                   = aws_cloudfront_distribution.scan_files_api.domain_name
     zone_id                = aws_cloudfront_distribution.scan_files_api.hosted_zone_id
-    evaluate_target_health = false
+    evaluate_target_health = true
+  }
+}
+
+resource "aws_route53_health_check" "scan_files_A" {
+  fqdn              = aws_route53_record.scan_files_A.fqdn
+  port              = 443
+  type              = "HTTPS"
+  resource_path     = "/healthcheck"
+  failure_threshold = "5"
+  request_interval  = "60"
+
+  tags = {
+    CostCentre = var.billing_code
+    Terraform  = true
   }
 }


### PR DESCRIPTION
# Summary
Add Route53 health check to keep the Scan Files API lambda warm.
Also updates CloudFront so that the `/healthcheck` path is not
cached.

# Related
* cds-snc/forms-terraform#224