### PR TITLE
feat: on-demand rescan via api parameter

### DIFF
--- a/api/clamav_scanner/clamav.py
+++ b/api/clamav_scanner/clamav.py
@@ -185,7 +185,7 @@ def scan_output_to_json(output):
     return summary
 
 
-def scan_file(session, path, aws_account=None):
+def scan_file(session, path, ignore_cache=False, aws_account=None):
     av_env = os.environ.copy()
     av_env["LD_LIBRARY_PATH"] = CLAMAVLIB_PATH
     log.info("Starting clamscan of %s." % path)
@@ -211,7 +211,7 @@ def scan_file(session, path, aws_account=None):
 
     # Check for previously cached scan results
     previous_scan = None
-    if AV_SCAN_USE_CACHE:
+    if AV_SCAN_USE_CACHE and not ignore_cache:
         current_time = datetime.datetime.utcnow()
         one_day_ago = current_time - datetime.timedelta(days=1)
 

--- a/api/clamav_scanner/scan.py
+++ b/api/clamav_scanner/scan.py
@@ -66,7 +66,9 @@ def launch_background_scan(
     )
 
 
-def launch_scan(file_path, scan_id, aws_account=None, session=None, sns_arn=None):
+def launch_scan(
+    file_path, scan_id, ignore_cache=False, aws_account=None, session=None, sns_arn=None
+):
     if session is None:
         session = next(get_db_session())
 
@@ -76,7 +78,7 @@ def launch_scan(file_path, scan_id, aws_account=None, session=None, sns_arn=None
     scan = session.query(Scan).filter(Scan.id == scan_id).one_or_none()
     try:
         checksum, scan_result, scan_signature, scanned_path = scan_file(
-            session, file_path, aws_account
+            session, file_path, ignore_cache, aws_account
         )
         scan.completed = datetime.datetime.utcnow()
         scan.verdict = determine_verdict(ScanProviders.CLAMAV.value, scan_result)


### PR DESCRIPTION
ability to override cache settings via a new query parameter `ignore_cache` when calling the `/clamav` endpoint.

![image](https://user-images.githubusercontent.com/85885638/177365588-dc47b53c-3b43-42fd-a1c7-d2f6712ec40b.png)
