### PR TITLE
fix: move socket connection into try/catch

### DIFF
--- a/api/clamav_scanner/clamav.py
+++ b/api/clamav_scanner/clamav.py
@@ -288,10 +288,10 @@ def is_clamd_running():
 
     if os.path.exists(CLAMD_SOCKET):
         with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as s:
-            s.settimeout(10)
-            s.connect(CLAMD_SOCKET)
-            s.send(b"PING")
             try:
+                s.settimeout(10)
+                s.connect(CLAMD_SOCKET)
+                s.send(b"PING")
                 data = s.recv(32)
             except (socket.timeout, socket.error) as e:
                 log.error("Failed to read from socket: %s\n" % e)


### PR DESCRIPTION
# Summary
Update the `is_clamd_running` function to perform the
sockect connection within the `try/catch` block.

Reason being that if the socket cannot be connected to,
we want to return `False` for the check and attempt
to start the ClamAV daemon.

# Related
* cds-snc/forms-terraform#224