### PR TITLE
fix: use urlparse to determine s3 bucket and key

### DIFF
--- a/api/storage/storage.py
+++ b/api/storage/storage.py
@@ -18,13 +18,11 @@ def get_file(save_path, aws_account=None, ref_only=False):
         client = get_session(credentials).resource("s3")
 
     try:
-        basename = key.split("/")[-1].strip()
-
         file = TemporaryFile()
         if ref_only:
-            client.Bucket(bucket).download_fileobj(basename, file)
+            client.Bucket(bucket).download_fileobj(key, file)
         else:
-            client.Bucket(bucket).download_fileobj(basename, file)
+            client.Bucket(bucket).download_fileobj(key, file)
             file.seek(0)
             file = file.read()
 


### PR DESCRIPTION
Original code assumed all files would be in the root directory. This change will use the full key incase items are within folders.