### PR TITLE
fix: prevent S3 folder objects from being scanned

### DIFF
--- a/module/s3-scan-object/app.js
+++ b/module/s3-scan-object/app.js
@@ -168,7 +168,7 @@ const getS3ObjectFromRecord = (eventSource, record) => {
  * @returns Boolean True if the S3 object key is a folder
  */
 const isS3Folder = (s3Object) => {
-  return !!s3Object && typeof s3Object.Key == "string" && s3Object.Key.endsWith("/");
+  return !!s3Object && typeof s3Object.Key === "string" && s3Object.Key.endsWith("/");
 };
 
 /**

--- a/module/s3-scan-object/app.js
+++ b/module/s3-scan-object/app.js
@@ -69,6 +69,11 @@ exports.handler = async (event) => {
     let eventSource = getRecordEventSource(record);
     let s3Object = getS3ObjectFromRecord(eventSource, record);
 
+    // Do not scan S3 folder objects
+    if (isS3Folder(s3Object)) {
+      continue;
+    }
+
     // Start a scan of the new S3 object
     if (eventSource !== null && s3Object !== null) {
       if (eventSource === EVENT_RESCAN || eventSource === EVENT_S3) {
@@ -158,6 +163,15 @@ const getS3ObjectFromRecord = (eventSource, record) => {
 };
 
 /**
+ * Checks if an S3 object represents a folder, which have keys ending with a forward slash `/`.
+ * @param {{Bucket: string, Key: string}} s3Object S3 bucket and key
+ * @returns Boolean True if the S3 object key is a folder
+ */
+const isS3Folder = (s3Object) => {
+  return !!s3Object && typeof s3Object.Key == "string" && s3Object.Key.endsWith("/");
+};
+
+/**
  * Given an S3 object URL, parses the URL and returns the S3 object's bucket and key.
  * @param {String} url S3 object URL in format `s3://bucket/key`
  * @returns {{Bucket: string, Key: string}} S3 object bucket and key or null
@@ -241,6 +255,7 @@ exports.helpers = {
   getRecordEventSource,
   getS3ObjectFromRecord,
   initConfig,
+  isS3Folder,
   parseS3Url,
   startS3ObjectScan,
   tagS3Object,

--- a/module/s3-scan-object/app.test.js
+++ b/module/s3-scan-object/app.test.js
@@ -57,7 +57,7 @@ describe("handler", () => {
             bucket: { name: "smaug" },
             object: { key: "gold/" },
           },
-        },        
+        },
         {
           EventSource: "aws:sns",
           Sns: {

--- a/module/s3-scan-object/app.test.js
+++ b/module/s3-scan-object/app.test.js
@@ -16,6 +16,7 @@ const {
   getRecordEventSource,
   getS3ObjectFromRecord,
   initConfig,
+  isS3Folder,
   parseS3Url,
   startS3ObjectScan,
   tagS3Object,
@@ -51,6 +52,13 @@ describe("handler", () => {
           },
         },
         {
+          eventSource: "aws:s3",
+          s3: {
+            bucket: { name: "smaug" },
+            object: { key: "gold/" },
+          },
+        },        
+        {
           EventSource: "aws:sns",
           Sns: {
             MessageAttributes: {
@@ -78,7 +86,7 @@ describe("handler", () => {
     };
     const expectedResponse = {
       status: 200,
-      body: "Event records processesed: 4, Errors: 0",
+      body: "Event records processesed: 5, Errors: 0",
     };
 
     axios.post.mockResolvedValue({ status: 200 });
@@ -319,6 +327,24 @@ describe("initConfig", () => {
   test("throws an error on failure", async () => {
     mockSecretManagerClient.on(GetSecretValueCommand).rejectsOnce(new Error("nope"));
     await expect(initConfig()).rejects.toThrow("nope");
+  });
+});
+
+describe("isS3Folder", () => {
+  test("identifies folders", () => {
+    expect(isS3Folder({ Key: "foobar/" })).toBe(true);
+    expect(isS3Folder({ Key: "bam/baz/boom/" })).toBe(true);
+  });
+
+  test("identifies things that are not folders", () => {
+    expect(isS3Folder(null)).toBe(false);
+    expect(isS3Folder(undefined)).toBe(false);
+    expect(isS3Folder({ Key: "most-certainly-not-a-folder.png" })).toBe(false);
+    expect(isS3Folder({ Key: null })).toBe(false);
+    expect(isS3Folder({ Key: undefined })).toBe(false);
+    expect(isS3Folder({})).toBe(false);
+    expect(isS3Folder({ Key: "" })).toBe(false);
+    expect(isS3Folder({ Key: "some/nested/path/with/a/file.txt" })).toBe(false);
   });
 });
 


### PR DESCRIPTION
# Summary
Update the code so that newly created S3 folders are not scanned.
S3 folders can be identified by their trailing `/`.

# Related
* cds-snc/forms-terraform#224