### PR TITLE
fix: KMS key policy

### DIFF
--- a/terragrunt/aws/api/kms.tf
+++ b/terragrunt/aws/api/kms.tf
@@ -84,26 +84,6 @@ data "aws_iam_policy_document" "kms_policies" {
       identifiers = [local.api_role_arn]
     }
   }
-
-  statement {
-
-    sid = "S3ScanObject"
-
-    effect = "Allow"
-
-    actions = [
-      "kms:Decrypt"
-    ]
-
-    resources = [
-      "*"
-    ]
-
-    principals {
-      type        = "AWS"
-      identifiers = ["arn:aws:iam::${var.account_id}:role/s3-scan-object"]
-    }
-  }
 }
 
 resource "aws_kms_key" "scan-files" {

--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -5,7 +5,7 @@ module "api" {
   ecr_arn                = aws_ecr_repository.api.arn
   enable_lambda_insights = true
   image_uri              = "${aws_ecr_repository.api.repository_url}:latest"
-  memory                 = 1769
+  memory                 = 3008
   timeout                = 300
 
   vpc = {


### PR DESCRIPTION
# Summary
Remove principal for S3 scan object lambda function as it
does not exist yet.

Also increase the Lambda function memory to deal with
OOM process killed exceptions during load testing.

# ⚠️  Note
I applied the `api` module change locally to avoid exposing our 
AWS org ID in the plan since it had been marked as not sensitive 
in #165.

# Related
* #165 
* cds-snc/forms-terraform#224