### PR TITLE
fix: S3 scan object lambda image URI

### DIFF
--- a/terragrunt/aws/api/kms.tf
+++ b/terragrunt/aws/api/kms.tf
@@ -83,6 +83,11 @@ data "aws_iam_policy_document" "kms_policies" {
       type        = "AWS"
       identifiers = [local.api_role_arn]
     }
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${var.account_id}:role/s3-scan-object"]
+    }    
   }
 }
 

--- a/terragrunt/aws/api/kms.tf
+++ b/terragrunt/aws/api/kms.tf
@@ -87,7 +87,7 @@ data "aws_iam_policy_document" "kms_policies" {
     principals {
       type        = "AWS"
       identifiers = ["arn:aws:iam::${var.account_id}:role/s3-scan-object"]
-    }    
+    }
   }
 }
 

--- a/terragrunt/aws/s3_scan_object/lambda.tf
+++ b/terragrunt/aws/s3_scan_object/lambda.tf
@@ -2,7 +2,7 @@ module "s3_scan_object" {
   source = "github.com/cds-snc/terraform-modules?ref=v3.0.6//lambda"
 
   name      = "s3-scan-object"
-  image_uri = aws_ecr_repository.s3_scan_object.repository_url
+  image_uri = "${aws_ecr_repository.s3_scan_object.repository_url}:latest"
   ecr_arn   = aws_ecr_repository.s3_scan_object.arn
   memory    = 512
   timeout   = 15


### PR DESCRIPTION
# Summary
Add `:latest` tag to lambda image URI.

Also updates the KMS key policy to include the lambda
role ARN as a principal.

# ⚠️  Note
This was applied locally.

# Related
* #165 
* #166 
* cds-snc/forms-terraform#224