### PR TITLE
fix: use default SecretsManager encryption key

### DIFF
--- a/terragrunt/.checkov.yml
+++ b/terragrunt/.checkov.yml
@@ -5,6 +5,7 @@ skip-check:
   - CKV_AWS_117 # Lambda: access to VPC resources not required
   - CKV_AWS_120 # API Gateway: caching is not wanted
   - CKV_AWS_136 # ECR: default encryption key is acceptable 
+  - CKV_AWS_149 # SecretsManager: default encryption key is acceptable
   - CKV_AWS_158 # CloudWatch: default encryption key is acceptable
   - CKV_AWS_28  # Dynamodb point in time recovery is not required
   - CKV_AWS_119 # AWS Managed keys are acceptable

--- a/terragrunt/aws/api/kms.tf
+++ b/terragrunt/aws/api/kms.tf
@@ -83,11 +83,6 @@ data "aws_iam_policy_document" "kms_policies" {
       type        = "AWS"
       identifiers = [local.api_role_arn]
     }
-
-    principals {
-      type        = "AWS"
-      identifiers = ["arn:aws:iam::${var.account_id}:role/s3-scan-object"]
-    }
   }
 }
 

--- a/terragrunt/aws/api/outputs.tf
+++ b/terragrunt/aws/api/outputs.tf
@@ -26,10 +26,6 @@ output "invoke_arn" {
   value = module.api.invoke_arn
 }
 
-output "scan_files_api_key_kms_arn" {
-  value = aws_kms_key.scan-files.arn
-}
-
 output "scan_files_api_key_secret_arn" {
   value = aws_secretsmanager_secret.api_auth_token.arn
 }

--- a/terragrunt/aws/api/secrets.tf
+++ b/terragrunt/aws/api/secrets.tf
@@ -1,7 +1,5 @@
 resource "aws_secretsmanager_secret" "api_auth_token" {
-  name       = "/scan-files/api_auth_token"
-  kms_key_id = aws_kms_key.scan-files.arn
-
+  name = "/scan-files/api_auth_token"
   tags = {
     CostCentre = var.billing_code
     Terraform  = true

--- a/terragrunt/aws/s3_scan_object/inputs.tf
+++ b/terragrunt/aws/s3_scan_object/inputs.tf
@@ -3,11 +3,6 @@ variable "scan_files_api_function_role_arn" {
   type        = string
 }
 
-variable "scan_files_api_key_kms_arn" {
-  description = "ARN of the KMS key used to encrypt the Scan Files API key secret"
-  type        = string
-}
-
 variable "scan_files_api_key_secret_arn" {
   description = "ARN of the Scan Files API key secret"
   type        = string

--- a/terragrunt/aws/s3_scan_object/lambda.tf
+++ b/terragrunt/aws/s3_scan_object/lambda.tf
@@ -36,16 +36,6 @@ data "aws_iam_policy_document" "s3_scan_object" {
       var.scan_files_api_key_secret_arn
     ]
   }
-
-  statement {
-    effect = "Allow"
-    actions = [
-      "kms:Decrypt"
-    ]
-    resources = [
-      var.scan_files_api_key_kms_arn
-    ]
-  }
 }
 
 data "aws_iam_policy_document" "assume_cross_account" {
@@ -66,10 +56,9 @@ data "aws_iam_policy_document" "assume_cross_account" {
 }
 
 resource "aws_lambda_permission" "s3_scan_object_org_account_execute" {
-  statement_id  = "AllowExecutionFromOrgAccounts"
-  action        = "lambda:InvokeFunction"
-  function_name = module.s3_scan_object.function_name
-
+  statement_id     = "AllowExecutionFromOrgAccounts"
+  action           = "lambda:InvokeFunction"
+  function_name    = module.s3_scan_object.function_name
   principal        = "*"
   principal_org_id = var.aws_org_id
 }

--- a/terragrunt/env/production/s3_scan_object/terragrunt.hcl
+++ b/terragrunt/env/production/s3_scan_object/terragrunt.hcl
@@ -13,14 +13,12 @@ dependency "api" {
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
     function_role_arn                = ""
-    scan_files_api_key_kms_arn       = ""
     scan_files_api_key_secret_arn    = ""
   }
 }
 
 inputs = {
   scan_files_api_function_role_arn = dependency.api.outputs.function_role_arn
-  scan_files_api_key_kms_arn       = dependency.api.outputs.scan_files_api_key_kms_arn
   scan_files_api_key_secret_arn    = dependency.api.outputs.scan_files_api_key_secret_arn
 }
 


### PR DESCRIPTION
# Summary
Update the Scan Files API auth token secret to use the default
SecretsManager encryption key.

The reason we had initially used a CMK was because we were
providing cross-account access to the secret, so a CMK was
required for the decryption.  Now that cross-account access
secret access has been removed, we no longer need to use
the CMK.

# Related
* #165 
* cds-snc/forms-terraform#224