### PR TITLE
fix: reference to KMS key alias

### DIFF
--- a/terragrunt/aws/api/secrets.tf
+++ b/terragrunt/aws/api/secrets.tf
@@ -1,6 +1,6 @@
 resource "aws_secretsmanager_secret" "api_auth_token" {
   name       = "/scan-files/api_auth_token"
-  kms_key_id = "aws/secretsmanager"
+  kms_key_id = "alias/aws/secretsmanager"
   tags = {
     CostCentre = var.billing_code
     Terraform  = true


### PR DESCRIPTION
# Summary
The KMS key ID for the secret needs to start with `alias`
to properly find the key.

# ⚠️  Note
This was applied locally.

# Related
* #170
* cds-snc/forms-terraform#224