### PR TITLE
feat: explicit deploy of lambda functions

### DIFF
--- a/.github/manifests/lambda_api_version
+++ b/.github/manifests/lambda_api_version
@@ -1,0 +1,1 @@
+b91eaccd40041dcf1affab1abc69d812ad109c86

--- a/.github/manifests/lambda_s3_scan_object_version
+++ b/.github/manifests/lambda_s3_scan_object_version
@@ -1,0 +1,1 @@
+b91eaccd40041dcf1affab1abc69d812ad109c86

--- a/.github/workflows/build_and_push_production.yml
+++ b/.github/workflows/build_and_push_production.yml
@@ -1,4 +1,4 @@
-name: Build and Push Container to ECR, deploy to lambda
+name: Build and Push Container to ECR
 
 on:
   workflow_dispatch:
@@ -73,19 +73,6 @@ jobs:
       - name: Logout of Amazon ECR
         run: docker logout ${{ steps.login-ecr.outputs.registry }}
 
-      - name: Deploy lambda
-        if: matrix.image == 'api'
-        run: |
-          aws lambda update-function-code \
-            --function-name scan-files-api \
-            --image-uri $REGISTRY/${{ matrix.image }}:latest  > /dev/null 2>&1
-
-      - name: Migrate Database
-        if: matrix.image == 'api'
-        run: |
-          source .github/workflows/scripts/migrate.sh
-          migrate
-
       - name: Generate ${{ matrix.image }}/docker SBOM
         uses: cds-snc/security-tools/.github/actions/generate-sbom@4c6b386722985552f3f008d04279a3f01402cc35 # tag=v1
         with:
@@ -93,10 +80,3 @@ jobs:
           docker_image: $REGISTRY/${{ matrix.image }}:$GITHUB_SHA
           project_name: scan-files/${{ matrix.image }}/docker
           project_type: docker
-
-      - name: scan-files API healthcheck
-        uses: jtalk/url-health-check-action@d6ec9590f0f1bd173fa43aeac8b75c2270e9069d # renovate: tag=v2
-        with:
-          url: https://scan-files.alpha.canada.ca/version
-          max-attempts: 3
-          retry-delay: 5s

--- a/.github/workflows/deploy_lambda_production.yml
+++ b/.github/workflows/deploy_lambda_production.yml
@@ -1,0 +1,78 @@
+name: Deploy Lambda Docker images to production
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/manifests/lambda_api_version
+      - .github/manifests/lambda_s3_scan_object_version
+      - .github/workflows/deploy_lambda_production.yml
+
+env:
+  REGISTRY: 806545929748.dkr.ecr.ca-central-1.amazonaws.com/scan-files
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+  actions: write
+  checks: write
+  statuses: write
+
+jobs:
+  deploy-lambda:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - function: scan-files-api
+            image: api
+            version: .github/manifests/lambda_api_version
+
+          - function: s3-scan-object
+            image: module/s3-scan-object
+            version: .github/manifests/lambda_s3_scan_object_version
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3.0.2
+
+      - uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721 # tag=v2.10.2
+        id: filter
+        with:
+          filters: |
+            changes: '${{ matrix.version }}'
+
+      - name: Configure AWS credentials using OIDC
+        if: steps.filter.outputs.changes == 'true'
+        uses: aws-actions/configure-aws-credentials@05b148adc31e091bafbaf404f745055d4d3bc9d2 # tag=v1.6.1
+        with:
+          role-to-assume: arn:aws:iam::806545929748:role/OIDCGithubWorkflowRole
+          role-session-name: DeployLambda
+          aws-region: ca-central-1
+
+      - name: Deploy lambda
+        if: steps.filter.outputs.changes == 'true'
+        run: |
+          VERSION="$(cat ${{ matrix.version }})"
+          aws lambda update-function-code \
+            --function-name ${{ matrix.function }} \
+            --image-uri $REGISTRY/${{ matrix.image }}:$VERSION  > /dev/null 2>&1
+
+      - name: Migrate database
+        if: steps.filter.outputs.changes == 'true' && matrix.function == 'scan-files-api'
+        run: |
+          aws lambda wait function-active --function-name ${{ matrix.function }}
+          source .github/workflows/scripts/migrate.sh
+          migrate
+
+      - name: API healthcheck
+        if: steps.filter.outputs.changes == 'true'
+        uses: jtalk/url-health-check-action@d6ec9590f0f1bd173fa43aeac8b75c2270e9069d # renovate: tag=v2
+        with:
+          url: https://scan-files.alpha.canada.ca/version
+          max-attempts: 3
+          retry-delay: 5s


### PR DESCRIPTION
# Summary
Add lambda version manifests that control the Docker 
images that are deployed to Production for the
`scan-files-api` and `s3-scan-object` functions.

Once the Staging environment is setup, the `latest` 
Docker images will always be deployed on push to 
`main` in that account.

# Related
* cds-snc/forms-terraform#224