### PR TITLE
feat: add `RequestId` to S3 scan object flow

### DIFF
--- a/module/s3-scan-object/.prettierrc
+++ b/module/s3-scan-object/.prettierrc
@@ -1,1 +1,1 @@
-printWidth: 100
+printWidth: 120


### PR DESCRIPTION
# Summary
Update the S3 scan object lambda to pass the `RequestId` along to Scan files
and add it to log messages.  The request ID is passed as the following header:

```
X-Scanning-Request-Id
```

TODO: investigate if there's a more elegant way to have log messages
prefixed with this `RequestId` rather than passing it through to all
functions.

# Related
* cds-snc/forms-terraform#224
* cds-snc/terraform-modules#140
