### PR TITLE
feat: integration test infrastructure

### DIFF
--- a/.github/workflows/tf_apply_production.yml
+++ b/.github/workflows/tf_apply_production.yml
@@ -45,6 +45,9 @@ jobs:
             hosted_zone:
               - 'terragrunt/aws/hosted_zone/**'
               - 'terragrunt/env/production/hosted_zone/**'
+            integration_test:
+              - 'terragrunt/aws/integration_test/**'
+              - 'terragrunt/env/production/integration_test/**'              
             s3_scan_object:
               - 'terragrunt/aws/s3_scan_object/**'
               - 'terragrunt/env/production/s3_scan_object/**'                           
@@ -62,6 +65,12 @@ jobs:
       - name: Apply hosted_zone
         if: ${{ steps.filter.outputs.hosted_zone == 'true' }}
         working-directory: terragrunt/env/production/hosted_zone
+        run: |
+          terragrunt apply --terragrunt-non-interactive -auto-approve
+
+      - name: Apply integration_test
+        if: ${{ steps.filter.outputs.integration_test == 'true' }}
+        working-directory: terragrunt/env/production/integration_test
         run: |
           terragrunt apply --terragrunt-non-interactive -auto-approve
 

--- a/.github/workflows/tf_plan_production.yml
+++ b/.github/workflows/tf_plan_production.yml
@@ -30,6 +30,7 @@ jobs:
         include:
           - module: api
           - module: hosted_zone
+          - module: integration_test
           - module: s3_scan_object
           - module: scan_queue
 

--- a/terragrunt/aws/integration_test/s3_scan_object.tf
+++ b/terragrunt/aws/integration_test/s3_scan_object.tf
@@ -1,0 +1,29 @@
+module "integration_test" {
+  source = "github.com/cds-snc/terraform-modules?ref=v3.0.9//S3_scan_object"
+
+  product_name          = "integration-test"
+  s3_upload_bucket_name = module.integration_test_bucket.s3_bucket_id
+
+  billing_tag_value = var.billing_code
+}
+
+module "integration_test_bucket" {
+  source            = "github.com/cds-snc/terraform-modules?ref=v3.0.9//S3"
+  bucket_name       = "${var.product_name}-${var.env}-integration-test"
+  billing_tag_value = var.billing_code
+
+  lifecycle_rule = [
+    {
+      id      = "expire-objects-after-1-day"
+      enabled = true
+      expiration = {
+        days                         = 1
+        expired_object_delete_marker = true
+      }
+    },
+  ]
+
+  versioning = {
+    enabled = true
+  }
+}

--- a/terragrunt/env/production/integration_test/terragrunt.hcl
+++ b/terragrunt/env/production/integration_test/terragrunt.hcl
@@ -1,0 +1,7 @@
+terraform {
+  source = "../../../aws//integration_test"
+}
+
+include {
+  path = find_in_parent_folders()
+}


### PR DESCRIPTION
# Summary
Add the S3 scan object Terraform module to the account so that
it can be used for integration testing.

# Related
* cds-snc/forms-terraform#224