### PR TITLE
fix: use `while` loop in Lambda integration tests

### DIFF
--- a/.github/workflows/integration_test_production.yml
+++ b/.github/workflows/integration_test_production.yml
@@ -44,13 +44,19 @@ jobs:
       - name: Async test - wait for scan
         run: |
           COUNTER=0
-          until aws s3api get-object-tagging --bucket ${{ env.BUCKET_NAME }} --key ${{ env.FILENAME }} --output text | grep "av-checksum" > /dev/null; do
-            sleep 5
-            ((COUNTER++))
+          while true; do
+            CHECKSUM="$(aws s3api get-object-tagging --bucket ${{ env.BUCKET_NAME }} --key ${{ env.FILENAME }} --output text | grep 'av-checksum' || true)"
+            if [ "$CHECKSUM" != "" ]; then
+              break
+            fi
+            
+            COUNTER=$((COUNTER+1))
             if [ $COUNTER -gt 10 ]; then
-              echo "💩 Async scan failed"
+              echo "💩 Async scan timed out"
               exit 1
             fi
+
+            sleep 5
           done
 
       - name: Async test - expected verdict
@@ -79,7 +85,7 @@ jobs:
       - name: Slack message on failure
         if: failure()
         run: |
-          json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":red: Integration test failed: <https://github.com/cds-snc/notification-terraform/actions/workflows/integration_test_production.yml|Integration test production>"}}]}'
+          json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":red: Integration test failed: <https://github.com/cds-snc/scan-files/actions/workflows/integration_test_production.yml|Integration test production>"}}]}'
           curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.SCAN_FILES_PROD_OPS_WEBHOOK }}
 
       - name: Remove test file

--- a/.github/workflows/integration_test_production.yml
+++ b/.github/workflows/integration_test_production.yml
@@ -21,7 +21,7 @@ permissions:
   statuses: write
 
 jobs:
-  deploy-lambda:
+  integration-test-production:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
# Summary
Update the integration test polling to use a `while` loop instead
of `until`.  Reason for the change is that the exit code of `1` for
the `until` loop's grep command was causing the job step
to exit with an error.

# Related
* #177 