### PR TITLE
feat: add CloudWatch health check alarm

### DIFF
--- a/.github/workflows/tf_apply_production.yml
+++ b/.github/workflows/tf_apply_production.yml
@@ -6,7 +6,7 @@ on:
       - main
     paths:
       - "terragrunt/**"
-      - ".github/workflows/tf_apply_production.yml"      
+      - ".github/workflows/tf_apply_production.yml"
 
 env:
   TERRAFORM_VERSION: 1.0.3
@@ -14,6 +14,7 @@ env:
   TF_VAR_api_auth_token: ${{ secrets.PRODUCTION_API_AUTH_TOKEN }}
   TF_VAR_aws_org_id: ${{ secrets.AWS_ORG_ID }}
   TF_VAR_rds_password: ${{ secrets.PRODUCTION_RDS_PASSWORD }}
+  TF_VAR_slack_webhook_url: ${{ secrets.SCAN_FILES_PROD_OPS_WEBHOOK }}
   AWS_REGION: ca-central-1
 
 permissions:
@@ -39,6 +40,9 @@ jobs:
         id: filter
         with:
           filters: |
+            alarms:
+              - 'terragrunt/aws/alarms/**'
+              - 'terragrunt/env/production/alarms/**'
             api:
               - 'terragrunt/aws/api/**'
               - 'terragrunt/env/production/api/**'
@@ -47,10 +51,10 @@ jobs:
               - 'terragrunt/env/production/hosted_zone/**'
             integration_test:
               - 'terragrunt/aws/integration_test/**'
-              - 'terragrunt/env/production/integration_test/**'              
+              - 'terragrunt/env/production/integration_test/**'
             s3_scan_object:
               - 'terragrunt/aws/s3_scan_object/**'
-              - 'terragrunt/env/production/s3_scan_object/**'                           
+              - 'terragrunt/env/production/s3_scan_object/**'
             scan_queue:
               - 'terragrunt/aws/scan_queue/**'
               - 'terragrunt/env/production/scan_queue/**'
@@ -84,10 +88,16 @@ jobs:
         if: ${{ steps.filter.outputs.s3_scan_object == 'true' }}
         working-directory: terragrunt/env/production/s3_scan_object
         run: |
-          terragrunt apply --terragrunt-non-interactive -auto-approve 
+          terragrunt apply --terragrunt-non-interactive -auto-approve
 
       - name: Apply scan_queue
         if: ${{ steps.filter.outputs.scan_queue == 'true' }}
         working-directory: terragrunt/env/production/scan_queue
         run: |
-          terragrunt apply --terragrunt-non-interactive -auto-approve         
+          terragrunt apply --terragrunt-non-interactive -auto-approve
+
+      - name: Apply alarms
+        if: ${{ steps.filter.outputs.alarms == 'true' }}
+        working-directory: terragrunt/env/production/alarms
+        run: |
+          terragrunt apply --terragrunt-non-interactive -auto-approve

--- a/.github/workflows/tf_plan_production.yml
+++ b/.github/workflows/tf_plan_production.yml
@@ -13,6 +13,7 @@ env:
   TF_VAR_api_auth_token: ${{ secrets.PRODUCTION_API_AUTH_TOKEN }}
   TF_VAR_aws_org_id: ${{ secrets.AWS_ORG_ID }}
   TF_VAR_rds_password: ${{ secrets.PRODUCTION_RDS_PASSWORD }}
+  TF_VAR_slack_webhook_url: ${{ secrets.SCAN_FILES_PROD_OPS_WEBHOOK }}
 
 permissions:
   id-token: write
@@ -28,6 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - module: alarms
           - module: api
           - module: hosted_zone
           - module: integration_test

--- a/terragrunt/aws/alarms/alarms.tf
+++ b/terragrunt/aws/alarms/alarms.tf
@@ -1,0 +1,20 @@
+resource "aws_cloudwatch_metric_alarm" "route53_health_check_api" {
+  provider = aws.us-east-1
+
+  alarm_name          = "ScanFilesAPIHealthCheck"
+  alarm_description   = "Check that Scan Files API is healthy"
+  comparison_operator = "LessThanThreshold"
+  metric_name         = "HealthCheckStatus"
+  namespace           = "AWS/Route53"
+  period              = "60"
+  evaluation_periods  = "2"
+  statistic           = "Average"
+  threshold           = "1"
+  treat_missing_data  = "breaching"
+
+  alarm_actions = [aws_sns_topic.cloudwatch_warning_us_east.arn]
+
+  dimensions = {
+    HealthCheckId = var.route53_health_check_api_id
+  }
+}

--- a/terragrunt/aws/alarms/inputs.tf
+++ b/terragrunt/aws/alarms/inputs.tf
@@ -1,0 +1,10 @@
+variable "route53_health_check_api_id" {
+  description = "ID of the API's Route53 health check"
+  type        = string
+}
+
+variable "slack_webhook_url" {
+  description = "Slack webhook URL that will be used to send notifications"
+  type        = string
+  sensitive   = true
+}

--- a/terragrunt/aws/alarms/lambda.tf
+++ b/terragrunt/aws/alarms/lambda.tf
@@ -5,36 +5,9 @@ module "cloudwatch_alarms_slack" {
   project_name      = var.product_name
   slack_webhook_url = var.slack_webhook_url
   sns_topic_arns = [
-    aws_sns_topic.warning.arn,
-    aws_sns_topic.warning_us_east.arn
+    aws_sns_topic.cloudwatch_warning.arn,
+    aws_sns_topic.cloudwatch_warning_us_east.arn
   ]
 
   billing_tag_value = var.billing_code
-}
-
-#
-# SNS: topic & subscription
-#
-resource "aws_sns_topic" "cloudwatch_warning" {
-  # checkov:skip=CKV_AWS_26: encryption-at-rest not required for alarm topic
-  name = "cloudwatch-alarms-warning"
-}
-
-resource "aws_sns_topic_subscription" "alert_warning" {
-  topic_arn = aws_sns_topic.cloudwatch_warning.arn
-  protocol  = "lambda"
-  endpoint  = module.cloudwatch_alarms_slack.lambda_arn
-}
-
-resource "aws_sns_topic" "cloudwatch_warning_us_east" {
-  # checkov:skip=CKV_AWS_26: encryption-at-rest not required for alarm topic
-  provider = aws.us-east-1
-  name     = "cloudwatch-alarms-warning"
-}
-
-resource "aws_sns_topic_subscription" "alert_warning_us_east" {
-  provider  = aws.us-east-1
-  topic_arn = aws_sns_topic.cloudwatch_warning_us_east.arn
-  protocol  = "lambda"
-  endpoint  = module.cloudwatch_alarms_slack.lambda_arn
 }

--- a/terragrunt/aws/alarms/lambda.tf
+++ b/terragrunt/aws/alarms/lambda.tf
@@ -1,0 +1,40 @@
+module "cloudwatch_alarms_slack" {
+  source = "github.com/cds-snc/terraform-modules?ref=v3.0.9//notify_slack"
+
+  function_name     = "cloudwatch-alarms-slack"
+  project_name      = var.product_name
+  slack_webhook_url = var.slack_webhook_url
+  sns_topic_arns = [
+    aws_sns_topic.warning.arn,
+    aws_sns_topic.warning_us_east.arn
+  ]
+
+  billing_tag_value = var.billing_code
+}
+
+#
+# SNS: topic & subscription
+#
+resource "aws_sns_topic" "cloudwatch_warning" {
+  # checkov:skip=CKV_AWS_26: encryption-at-rest not required for alarm topic
+  name = "cloudwatch-alarms-warning"
+}
+
+resource "aws_sns_topic_subscription" "alert_warning" {
+  topic_arn = aws_sns_topic.cloudwatch_warning.arn
+  protocol  = "lambda"
+  endpoint  = module.cloudwatch_alarms_slack.lambda_arn
+}
+
+resource "aws_sns_topic" "cloudwatch_warning_us_east" {
+  # checkov:skip=CKV_AWS_26: encryption-at-rest not required for alarm topic
+  provider = aws.us-east-1
+  name     = "cloudwatch-alarms-warning"
+}
+
+resource "aws_sns_topic_subscription" "alert_warning_us_east" {
+  provider  = aws.us-east-1
+  topic_arn = aws_sns_topic.cloudwatch_warning_us_east.arn
+  protocol  = "lambda"
+  endpoint  = module.cloudwatch_alarms_slack.lambda_arn
+}

--- a/terragrunt/aws/alarms/sns.tf
+++ b/terragrunt/aws/alarms/sns.tf
@@ -1,0 +1,26 @@
+#
+# SNS: topic & subscription
+#
+resource "aws_sns_topic" "cloudwatch_warning" {
+  # checkov:skip=CKV_AWS_26: encryption-at-rest not required for alarm topic
+  name = "cloudwatch-alarms-warning"
+}
+
+resource "aws_sns_topic_subscription" "alert_warning" {
+  topic_arn = aws_sns_topic.cloudwatch_warning.arn
+  protocol  = "lambda"
+  endpoint  = module.cloudwatch_alarms_slack.lambda_arn
+}
+
+resource "aws_sns_topic" "cloudwatch_warning_us_east" {
+  # checkov:skip=CKV_AWS_26: encryption-at-rest not required for alarm topic
+  provider = aws.us-east-1
+  name     = "cloudwatch-alarms-warning"
+}
+
+resource "aws_sns_topic_subscription" "alert_warning_us_east" {
+  provider  = aws.us-east-1
+  topic_arn = aws_sns_topic.cloudwatch_warning_us_east.arn
+  protocol  = "lambda"
+  endpoint  = module.cloudwatch_alarms_slack.lambda_arn
+}

--- a/terragrunt/aws/api/outputs.tf
+++ b/terragrunt/aws/api/outputs.tf
@@ -26,6 +26,10 @@ output "invoke_arn" {
   value = module.api.invoke_arn
 }
 
+output "route53_health_check_api_id" {
+  value = aws_route53_health_check.scan_files_A.id
+}
+
 output "scan_files_api_key_secret_arn" {
   value = aws_secretsmanager_secret.api_auth_token.arn
 }

--- a/terragrunt/aws/integration_test/s3_scan_object.tf
+++ b/terragrunt/aws/integration_test/s3_scan_object.tf
@@ -18,7 +18,7 @@ module "integration_test_bucket" {
       enabled = true
       expiration = {
         days                         = 1
-        expired_object_delete_marker = true
+        expired_object_delete_marker = false
       }
     },
   ]

--- a/terragrunt/env/production/alarms/terragrunt.hcl
+++ b/terragrunt/env/production/alarms/terragrunt.hcl
@@ -1,0 +1,25 @@
+terraform {
+  source = "../../../aws//alarms"
+}
+
+dependencies {
+  paths = ["../api"]
+}
+
+dependency "api" {
+  config_path = "../api"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+  mock_outputs = {
+    route53_health_check_api_id = ""
+  }
+}
+
+inputs = {
+  route53_health_check_api_id = dependency.api.outputs.route53_health_check_api_id
+}
+
+include {
+  path = find_in_parent_folders()
+}


### PR DESCRIPTION
# Summary
Add a CloudWatch alarm that posts to Slack if the Route53 API
health check is failing.

# Related
* cds-snc/forms-terraform#224