### PR TITLE
feat: track scan request lifecycle

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -15,7 +15,7 @@ ARG SHELLCHECK_CHECKSUM
 
 # Install packages
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends clamav clamav-daemon \
+    && apt-get -y install --no-install-recommends clamav clamav-daemon clamdscan \
     && apt-get autoremove -y && apt-get clean -y
 
 # Install ShellCheck
@@ -68,9 +68,12 @@ RUN chown -R vscode:vscode /home/vscode/.aws
 RUN mkdir -p /tmp/clamav \
  && mkdir -p /tmp/clamav/quarantine \
  && chown -R vscode:vscode /tmp/clamav /var/log/clamav \
- && sed -i 's/User clamav/User vscode/g' /etc/clamav/clamd.conf \
+ && sed -i 's=DatabaseDirectory /var/lib/clamav=DatabaseDirectory /tmp/clamav=g' /etc/clamav/clamd.conf \
  && sed -i 's/CompressLocalDatabase no/CompressLocalDatabase yes/g' /etc/clamav/freshclam.conf \
- && sed -i 's/DatabaseOwner clamav/DatabaseOwner vscode/g' /etc/clamav/freshclam.conf \
+ && sed -i 's=LogFile /var/log/clamav/clamav.log=LogFile /tmp/clamav.log=g' /etc/clamav/clamd.conf \ 
+ && sed -i 's=LocalSocket /var/run/clamav/clamd.ctl=LocalSocket /tmp/clamd.sock=g' /etc/clamav/clamd.conf \ 
+ && sed -i 's=LocalSocketGroup clamav=# LocalSocketGroup python=g' /etc/clamav/clamd.conf \
+ && echo "PidFile /tmp/clamd.pid" >> /etc/clamav/clamd.conf \ 
  && sed -i 's=UpdateLogFile /var/log/clamav/freshclam.log=UpdateLogFile /tmp/clamav/freshclam.log=g' /etc/clamav/freshclam.conf
 
 

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -10,7 +10,7 @@ x-api_envs: &api_envs
   AV_DEFINITION_PATH: "/tmp/clamav"
   AV_DEFINITION_S3_BUCKET: "clamav-defs"
   CLAMAVLIB_PATH: "/etc/clamav"
-  CLAMDSCAN_PATH: "/usr/bin/clamscan"
+  CLAMDSCAN_PATH: "/usr/bin/clamdscan"
   FRESHCLAM_PATH: "/usr/bin/freshclam"
 
 services:
@@ -42,7 +42,7 @@ services:
     image: postgres:11.16
     volumes:
     - ./initdb:/docker-entrypoint-initdb.d
-    restart: always
+    restart: unless-stopped
     command:
       - "postgres"
       - "-c"
@@ -61,7 +61,7 @@ services:
     image: postgres:11.16
     volumes:
     - ./initdb:/docker-entrypoint-initdb.d
-    restart: always
+    restart: unless-stopped
     command:
       - "postgres"
       - "-c"

--- a/api/api_gateway/api.py
+++ b/api/api_gateway/api.py
@@ -5,7 +5,7 @@ from pydantic import BaseSettings
 from starlette.middleware.base import BaseHTTPMiddleware
 from uuid import uuid4
 
-from .custom_middleware import add_security_headers
+from .custom_middleware import add_security_headers, log_requests
 from .routers import ops, assemblyline, clamav
 
 
@@ -33,9 +33,7 @@ app = FastAPI(
 app.include_router(ops.router)
 app.include_router(assemblyline.router, prefix="/assemblyline", tags=["assemblyline"])
 app.include_router(clamav.router, prefix="/clamav", tags=["clamav"])
-
-# https://github.com/tiangolo/fastapi/issues/1472; can't include custom middlware when running tests
-if environ.get("CI") is None:
-    app.add_middleware(BaseHTTPMiddleware, dispatch=add_security_headers)
+app.add_middleware(BaseHTTPMiddleware, dispatch=log_requests)
+app.add_middleware(BaseHTTPMiddleware, dispatch=add_security_headers)
 
 metrics = Metrics(namespace="ScanFiles", service="api")

--- a/api/api_gateway/custom_middleware.py
+++ b/api/api_gateway/custom_middleware.py
@@ -1,6 +1,10 @@
 from fastapi import HTTPException, Request
 from os import environ
 from uuid import uuid4
+from logger import CustomLogger
+import time
+import types
+
 
 API_AUTH_TOKEN = environ.get("API_AUTH_TOKEN", uuid4())
 
@@ -10,6 +14,29 @@ async def add_security_headers(request: Request, call_next):
     response.headers[
         "Strict-Transport-Security"
     ] = "max-age=63072000; includeSubDomains; preload"
+    return response
+
+
+async def log_requests(request: Request, call_next):
+
+    # Inject a custom logger into the request object if API wasn't invoked by a lambda function
+    if "aws.context" not in request.scope:
+        request.scope["aws.context"] = types.SimpleNamespace()
+        request.scope["aws.context"].logger = CustomLogger("scan-files", None)
+
+    log = request.scope["aws.context"].logger.log
+    log.info(f"start request path={request.url.path}")
+
+    start_time = time.time()
+
+    response = await call_next(request)
+
+    process_time = (time.time() - start_time) * 1000
+    formatted_process_time = "{0:.2f}".format(process_time)
+    log.info(
+        f"completed_in={formatted_process_time}ms status_code={response.status_code}"
+    )
+
     return response
 
 

--- a/api/clamav_scanner/clamav.py
+++ b/api/clamav_scanner/clamav.py
@@ -184,7 +184,7 @@ def scan_output_to_json(output):
     return summary
 
 
-def scan_file(session, path, ignore_cache=False, aws_account=None):
+def scan_file(log, session, path, ignore_cache=False, aws_account=None):
     av_env = os.environ.copy()
     av_env["LD_LIBRARY_PATH"] = CLAMAVLIB_PATH
     log.info("Starting clamscan of %s." % path)
@@ -251,12 +251,12 @@ def scan_file(session, path, ignore_cache=False, aws_account=None):
     # Turn the output into a data source we can read
     summary = scan_output_to_json(output)
     verdict, signature = determine_verdict(
-        ScanProviders.CLAMAV.value, path, summary, av_proc
+        log, ScanProviders.CLAMAV.value, path, summary, av_proc
     )
     return checksum, verdict, signature, path
 
 
-def determine_verdict(provider, path, summary, av_proc):
+def determine_verdict(log, provider, path, summary, av_proc):
     if None in (provider, path, summary, av_proc):
         log.error(
             f"determine_verdict called with missing arguments: {provider}, {path}, {summary}, {av_proc}"

--- a/api/logger.py
+++ b/api/logger.py
@@ -1,4 +1,43 @@
-import logzero
+import logging
+import re
+from uuid import uuid4
+from pythonjsonlogger import jsonlogger
 
-logzero.json()
-log = logzero.logger
+CUSTOM_FORMAT = "[%(request_id)s][%(asctime)s %(filename)s %(funcName)s %(levelname)1.1s %(module)s:%(lineno)d] %(message)s %(name)s %(pathname)s %(process)s %(processName)s %(threadName)s"
+
+
+class CustomLogger:
+    def __init__(self, logger_name, scanning_request_id):
+        self.scanning_request_id = scanning_request_id
+        self.old_factory = logging.getLogRecordFactory()
+        self.log = self.get_named_instance(logger_name, scanning_request_id)
+
+    def record_factory(self, *args, **kwargs):
+        record = self.old_factory(*args, **kwargs)
+        record.request_id = self.scanning_request_id
+        return record
+
+    def get_named_instance(self, name, scanning_request_id):
+        if not scanning_request_id or not re.match(r"^[\w-]+$", scanning_request_id):
+            self.scanning_request_id = "scan-request-{}".format(uuid4())
+
+        logging.setLogRecordFactory(self.record_factory)
+        logger = logging.getLogger(name)
+        logger.setLevel(logging.INFO)
+        handler = logging.StreamHandler()
+        handler.setLevel(logging.INFO)
+        formatter = jsonlogger.JsonFormatter(CUSTOM_FORMAT)
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+        return logger
+
+    def get_scanning_request_id(self):
+        return self.scanning_request_id
+
+
+log = logging.getLogger("scan-files")
+log.setLevel(logging.INFO)
+logHandler = logging.StreamHandler()
+formatter = jsonlogger.JsonFormatter()
+logHandler.setFormatter(formatter)
+log.addHandler(logHandler)

--- a/api/logger.py
+++ b/api/logger.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from os import environ
 from uuid import uuid4
 from pythonjsonlogger import jsonlogger
 
@@ -23,9 +24,8 @@ class CustomLogger:
 
         logging.setLogRecordFactory(self.record_factory)
         logger = logging.getLogger(name)
-        logger.setLevel(logging.INFO)
+        logger.setLevel(environ.get("LOG_LEVEL", logging.INFO))
         handler = logging.StreamHandler()
-        handler.setLevel(logging.INFO)
         formatter = jsonlogger.JsonFormatter(CUSTOM_FORMAT)
         handler.setFormatter(formatter)
         logger.addHandler(handler)
@@ -36,7 +36,7 @@ class CustomLogger:
 
 
 log = logging.getLogger("scan-files")
-log.setLevel(logging.INFO)
+log.setLevel(environ.get("LOG_LEVEL", logging.INFO))
 logHandler = logging.StreamHandler()
 formatter = jsonlogger.JsonFormatter()
 logHandler.setFormatter(formatter)

--- a/api/main.py
+++ b/api/main.py
@@ -12,7 +12,7 @@ from clamav_scanner.clamav import is_clamd_running, setup_clamd_daemon
 from aws_lambda_powertools import Metrics
 from database.dynamodb import get_scan_result
 from database.migrate import migrate_head
-from logger import log
+from logger import log, CustomLogger
 from mangum import Mangum
 from os import environ
 
@@ -36,6 +36,16 @@ def handler(event, context):
         "requestContext" in event and "http" in event["requestContext"]
     ):
         # Assume it is a request to the lambda function url
+        scanning_request_id = (
+            event["headers"]["X-Scanning-Request-Id"]
+            if "X-Scanning-Request-Id" in event["headers"]
+            else None
+        )
+        if scanning_request_id:
+            context.logger = CustomLogger(context.aws_request_id, scanning_request_id)
+        else:
+            context.logger = log
+
         asgi_handler = Mangum(app)
         response = asgi_handler(event, context)
         return response
@@ -53,7 +63,11 @@ def handler(event, context):
         return resubmit_stale_scans()
 
     elif event.get("task", "") == CLAMAV_LAMBDA_SCAN_TASK_NAME:
+        event_logger = CustomLogger(
+            context.aws_request_id, event.get("scanning_request_id", None)
+        )
         return clamav_launch_scan(
+            log=event_logger.log,
             file_path=event.get("file_path"),
             scan_id=event.get("scan_id"),
             aws_account=event.get("aws_account"),

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -3,7 +3,7 @@ assemblyline-client==4.4.1
 aws-lambda-powertools==1.26.0
 boto3==1.24.2
 fastapi==0.78.0
-logzero==1.7.0
+python-json-logger==2.0.4
 mangum==0.15.0
 psycopg2-binary==2.9.3
 python-multipart

--- a/api/tests/clamav/test_scan.py
+++ b/api/tests/clamav/test_scan.py
@@ -18,7 +18,7 @@ def test_clamav_scan(
 ):
     scan = ScanFactory(verdict=ScanVerdicts.IN_PROGRESS.value, meta_data={"sid": "123"})
     session.commit()
-
+    mock_logger = MagicMock()
     mock_scan_file.return_value = (
         "123",
         ScanVerdicts.CLEAN.value,
@@ -26,6 +26,7 @@ def test_clamav_scan(
         "/foo/bar/file.txt",
     )
     scan_verdict = launch_scan(
+        mock_logger,
         "/tmp/foo",  # nosec - [B108:hardcoded_tmp_directory] no risk in tests
         scan.id,
         session=session,
@@ -47,7 +48,9 @@ def test_sns_scan_results(mock_db_session, mock_aws_session, session):
     )
     session.commit()
     mock_sns_client = MagicMock()
+    mock_logger = MagicMock()
     sns_scan_results(
+        mock_logger,
         mock_sns_client,
         scan,
         "arn:aws:sns:ca-central-1:000000000000:clamav_scan-topic",
@@ -79,8 +82,10 @@ def test_sns_scan_results_error(mock_db_session, mock_aws_session, session):
         checksum="",
     )
     session.commit()
+    mock_logger = MagicMock()
     mock_sns_client = MagicMock()
     sns_scan_results(
+        mock_logger,
         mock_sns_client,
         scan,
         "arn:aws:sns:ca-central-1:000000000000:clamav_scan-topic",

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -35,6 +35,7 @@ def assert_new_model_saved():
 def context_fixture():
     context = MagicMock()
     context.function_name = "scan-files-api"
+    context.aws_request_id = "request_id"
     return context
 
 

--- a/api/tests/test_main.py
+++ b/api/tests/test_main.py
@@ -12,13 +12,17 @@ def test_handler_api_gateway_event(mock_mangum, context_fixture, capsys):
     assert (
         main.handler(
             {
+                "headers": {
+                    "Accept": "application/json",
+                    "Content-Type": "application/json",
+                },
                 "requestContext": {
                     "http": {
                         "method": "POST",
                         "path": "/foo",
                         "protocol": "HTTP/1.1",
                     }
-                }
+                },
             },
             context_fixture,
         )
@@ -26,13 +30,17 @@ def test_handler_api_gateway_event(mock_mangum, context_fixture, capsys):
     )
     mock_asgi_handler.assert_called_once_with(
         {
+            "headers": {
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+            },
             "requestContext": {
                 "http": {
                     "method": "POST",
                     "path": "/foo",
                     "protocol": "HTTP/1.1",
                 }
-            }
+            },
         },
         context_fixture,
     )

--- a/bin/api_healthcheck.sh
+++ b/bin/api_healthcheck.sh
@@ -6,7 +6,7 @@ curl "http://api:8080/2015-03-31/functions/function/invocations" -d '{
     "path": "/healthcheck",
     "requestContext": {},
     "httpMethod": "GET",
-    "headers": {},
+    "headers": {"X-Scanning-Request-Id": "bar"},
     "multiValueHeaders": { },
     "queryStringParameters": null,
     "multiValueQueryStringParameters": null,


### PR DESCRIPTION
Scan-files now expects a `X-Scanning-Request-Id` header and will use that to create contextual logging. These new loggers will be passed into any method where we'd like to track the lifecycle of a specific `X-Scanning-Request-Id`