### PR TITLE
fix: treat non-zero pidof command as info

### DIFF
--- a/api/clamav_scanner/clamav.py
+++ b/api/clamav_scanner/clamav.py
@@ -287,6 +287,9 @@ def get_clamd_pid():
     try:
         clamd_pid = subprocess.check_output(["pidof", "clamd"]).decode("utf-8").strip()
         return int(clamd_pid)
+    except subprocess.CalledProcessError as e:
+        log.info("Clamd is not running: %s" % e)
+        pass
     except ValueError:
         log.error("Failed to convert PID: %s into an integer" % clamd_pid)
         pass


### PR DESCRIPTION
# Summary
Update `get_clamd_pid` to treat a non-zero exit code from the
pidof command as expected as this will return `1` in cases where
the `clamd` process is not running.

Failures to start `clamd` will still result in an ERROR logged thanks
to the behaviour of `start_clamd_daemon`:
https://github.com/cds-snc/scan-files/blob/main/api/clamav_scanner/clamav.py#L344

# Related
* cds-snc/forms-terraform#224