### PR TITLE
feat: CloudWatch alarms for `ERROR` logs

### DIFF
--- a/terragrunt/aws/alarms/alarms.tf
+++ b/terragrunt/aws/alarms/alarms.tf
@@ -4,17 +4,77 @@ resource "aws_cloudwatch_metric_alarm" "route53_health_check_api" {
   alarm_name          = "ScanFilesAPIHealthCheck"
   alarm_description   = "Check that Scan Files API is healthy"
   comparison_operator = "LessThanThreshold"
-  metric_name         = "HealthCheckStatus"
-  namespace           = "AWS/Route53"
-  period              = "60"
-  evaluation_periods  = "2"
-  statistic           = "Average"
-  threshold           = "1"
-  treat_missing_data  = "breaching"
+
+  metric_name        = "HealthCheckStatus"
+  namespace          = "AWS/Route53"
+  period             = "60"
+  evaluation_periods = "2"
+  statistic          = "Average"
+  threshold          = "1"
+  treat_missing_data = "breaching"
 
   alarm_actions = [aws_sns_topic.cloudwatch_warning_us_east.arn]
+  ok_actions    = [aws_sns_topic.cloudwatch_warning_us_east.arn]
 
   dimensions = {
     HealthCheckId = var.route53_health_check_api_id
   }
+}
+
+resource "aws_cloudwatch_log_metric_filter" "scan_files_api_error" {
+  name           = "ErrorLoggedAPI"
+  pattern        = "ERROR"
+  log_group_name = var.scan_files_api_log_group_name
+
+  metric_transformation {
+    name      = "ErrorLoggedAPI"
+    namespace = "ScanFiles"
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "scan_files_api_error" {
+  alarm_name          = "ErrorLoggedAPI"
+  alarm_description   = "Errors logged by the Scan Files API lambda function"
+  comparison_operator = "GreaterThanThreshold"
+
+  metric_name        = aws_cloudwatch_log_metric_filter.scan_files_api_error.metric_transformation[0].name
+  namespace          = aws_cloudwatch_log_metric_filter.scan_files_api_error.metric_transformation[0].namespace
+  period             = "60"
+  evaluation_periods = "1"
+  statistic          = "Sum"
+  threshold          = var.scan_files_api_error_threshold
+  treat_missing_data = "notBreaching"
+
+  alarm_actions = [aws_sns_topic.cloudwatch_warning.arn]
+  ok_actions    = [aws_sns_topic.cloudwatch_warning.arn]
+}
+
+resource "aws_cloudwatch_log_metric_filter" "s3_scan_object_error" {
+  name           = "ErrorLoggedS3ScanObject"
+  pattern        = "ERROR"
+  log_group_name = var.s3_scan_object_log_group_name
+
+  metric_transformation {
+    name      = "ErrorLoggedS3ScanObject"
+    namespace = "ScanFiles"
+    value     = "1"
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "s3_scan_object_error" {
+  alarm_name          = "ErrorLoggedS3ScanObject"
+  alarm_description   = "Errors logged by the S3 scan object lambda function"
+  comparison_operator = "GreaterThanThreshold"
+  metric_name         = aws_cloudwatch_log_metric_filter.s3_scan_object_error.metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.s3_scan_object_error.metric_transformation[0].namespace
+
+  period             = "60"
+  evaluation_periods = "1"
+  statistic          = "Sum"
+  threshold          = var.s3_scan_object_error_threshold
+  treat_missing_data = "notBreaching"
+
+  alarm_actions = [aws_sns_topic.cloudwatch_warning.arn]
+  ok_actions    = [aws_sns_topic.cloudwatch_warning.arn]
 }

--- a/terragrunt/aws/alarms/alarms.tf
+++ b/terragrunt/aws/alarms/alarms.tf
@@ -1,3 +1,9 @@
+locals {
+  error_logged_api            = "ErrorLoggedAPI"
+  error_logged_s3_scan_object = "ErrorLoggedS3ScanObject"
+  error_namespace             = "ScanFiles"
+}
+
 resource "aws_cloudwatch_metric_alarm" "route53_health_check_api" {
   provider = aws.us-east-1
 
@@ -22,19 +28,19 @@ resource "aws_cloudwatch_metric_alarm" "route53_health_check_api" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "scan_files_api_error" {
-  name           = "ErrorLoggedAPI"
+  name           = local.error_logged_api
   pattern        = "ERROR"
   log_group_name = var.scan_files_api_log_group_name
 
   metric_transformation {
-    name      = "ErrorLoggedAPI"
-    namespace = "ScanFiles"
+    name      = local.error_logged_api
+    namespace = local.error_namespace
     value     = "1"
   }
 }
 
 resource "aws_cloudwatch_metric_alarm" "scan_files_api_error" {
-  alarm_name          = "ErrorLoggedAPI"
+  alarm_name          = local.error_logged_api
   alarm_description   = "Errors logged by the Scan Files API lambda function"
   comparison_operator = "GreaterThanThreshold"
 
@@ -51,19 +57,19 @@ resource "aws_cloudwatch_metric_alarm" "scan_files_api_error" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "s3_scan_object_error" {
-  name           = "ErrorLoggedS3ScanObject"
+  name           = local.error_logged_s3_scan_object
   pattern        = "ERROR"
   log_group_name = var.s3_scan_object_log_group_name
 
   metric_transformation {
-    name      = "ErrorLoggedS3ScanObject"
-    namespace = "ScanFiles"
+    name      = local.error_logged_s3_scan_object
+    namespace = local.error_namespace
     value     = "1"
   }
 }
 
 resource "aws_cloudwatch_metric_alarm" "s3_scan_object_error" {
-  alarm_name          = "ErrorLoggedS3ScanObject"
+  alarm_name          = local.error_logged_s3_scan_object
   alarm_description   = "Errors logged by the S3 scan object lambda function"
   comparison_operator = "GreaterThanThreshold"
   metric_name         = aws_cloudwatch_log_metric_filter.s3_scan_object_error.metric_transformation[0].name

--- a/terragrunt/aws/alarms/inputs.tf
+++ b/terragrunt/aws/alarms/inputs.tf
@@ -3,6 +3,26 @@ variable "route53_health_check_api_id" {
   type        = string
 }
 
+variable "s3_scan_object_log_group_name" {
+  description = "CloudWatch log group name for the S3 scan object lambda function"
+  type        = string
+}
+
+variable "s3_scan_object_error_threshold" {
+  description = "CloudWatch alarm threshold for the S3 scan object lambda function ERROR logs"
+  type        = string
+}
+
+variable "scan_files_api_log_group_name" {
+  description = "CloudWatch log group name for the Scan Files API lambda function"
+  type        = string
+}
+
+variable "scan_files_api_error_threshold" {
+  description = "CloudWatch alarm threshold for the Scan Files API lambda function ERROR logs"
+  type        = string
+}
+
 variable "slack_webhook_url" {
   description = "Slack webhook URL that will be used to send notifications"
   type        = string

--- a/terragrunt/aws/api/outputs.tf
+++ b/terragrunt/aws/api/outputs.tf
@@ -14,6 +14,10 @@ output "function_arn" {
   value = module.api.function_arn
 }
 
+output "function_log_group_name" {
+  value = "/var/lambda/${module.api.function_name}"
+}
+
 output "function_name" {
   value = module.api.function_name
 }

--- a/terragrunt/aws/s3_scan_object/outputs.tf
+++ b/terragrunt/aws/s3_scan_object/outputs.tf
@@ -1,0 +1,3 @@
+output "function_log_group_name" {
+  value = "/var/lambda/${module.s3_scan_object.function_name}"
+}

--- a/terragrunt/env/production/alarms/.terraform.lock.hcl
+++ b/terragrunt/env/production/alarms/.terraform.lock.hcl
@@ -1,0 +1,40 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.2.0"
+  hashes = [
+    "h1:CIWi5G6ob7p2wWoThRQbOB8AbmFlCzp7Ka81hR3cVp0=",
+    "zh:06bd875932288f235c16e2237142b493c2c2b6aba0e82e8c85068332a8d2a29e",
+    "zh:0c681b481372afcaefddacc7ccdf1d3bb3a0c0d4678a526bc8b02d0c331479bc",
+    "zh:100fc5b3fc01ea463533d7bbfb01cb7113947a969a4ec12e27f5b2be49884d6c",
+    "zh:55c0d7ddddbd0a46d57c51fcfa9b91f14eed081a45101dbfc7fd9d2278aa1403",
+    "zh:73a5dd68379119167934c48afa1101b09abad2deb436cd5c446733e705869d6b",
+    "zh:841fc4ac6dc3479981330974d44ad2341deada8a5ff9e3b1b4510702dfbdbed9",
+    "zh:91be62c9b41edb137f7f835491183628d484e9d6efa82fcb75cfa538c92791c5",
+    "zh:acd5f442bd88d67eb948b18dc2ed421c6c3faee62d3a12200e442bfff0aa7d8b",
+    "zh:ad5720da5524641ad718a565694821be5f61f68f1c3c5d2cfa24426b8e774bef",
+    "zh:e63f12ea938520b3f83634fc29da28d92eed5cfbc5cc8ca08281a6a9c36cca65",
+    "zh:f6542918faa115df46474a36aabb4c3899650bea036b5f8a5e296be6f8f25767",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "4.22.0"
+  constraints = "~> 4.9"
+  hashes = [
+    "h1:RxPzK6VFHz6qZMZUVhE03j9Cf5CvnLr14egtq5yxD1E=",
+    "zh:299efb8ba733b7742f0ef1c5c5467819e0c7bf46264f5f36ba6b6674304a5244",
+    "zh:4db198a41d248491204d4ca644662c32f748177d5cbe01f3c7adbb957d4d77f0",
+    "zh:62ebc2b05b25eafecb1a75f19d6fc5551faf521ada9df9e5682440d927f642e1",
+    "zh:636b590840095b4f817c176034cf649f543c0ce514dc051d6d0994f0a05c53ef",
+    "zh:8594bd8d442288873eee56c0b4535cbdf02cacfcf8f6ddcf8cd5f45bb1d3bc80",
+    "zh:8e18a370949799f20ba967eec07a84aaedf95b3ee5006fe5af6eae13fbf39dc3",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:aa968514231e404fb53311d8eae2e8b6bde1fdad1f4dd5a592ab93d9cbf11af4",
+    "zh:af8e5c48bf36d4fff1a6fca760d5b85f14d657cbdf95e9cd5e898c68104bad31",
+    "zh:d8a75ba36bf8b6f2e49be5682f48eccb6c667a4484afd676ae347213ae208622",
+    "zh:dd7c419674a47e587dabe98b150a8f1f7e31c248c68e8bf5e9ca0a400b5e2c4e",
+    "zh:fdeb6314a2ce97489bbbece59511f78306955e8a23b02cbd1485bd04185a3673",
+  ]
+}

--- a/terragrunt/env/production/alarms/terragrunt.hcl
+++ b/terragrunt/env/production/alarms/terragrunt.hcl
@@ -3,7 +3,7 @@ terraform {
 }
 
 dependencies {
-  paths = ["../api"]
+  paths = ["../api", "../s3_scan_object"]
 }
 
 dependency "api" {
@@ -12,12 +12,28 @@ dependency "api" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
+    function_log_group_name     = "/var/lambda/scan-files-api"
     route53_health_check_api_id = ""
   }
 }
 
+dependency "s3_scan_object" {
+  config_path = "../s3_scan_object"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+  mock_outputs = {
+    function_log_group_name = "/var/lambda/s3-scan-object"
+  }
+}
+
 inputs = {
-  route53_health_check_api_id = dependency.api.outputs.route53_health_check_api_id
+  s3_scan_object_log_group_name = dependency.s3_scan_object.outputs.function_log_group_name
+  scan_files_api_log_group_name = dependency.api.outputs.function_log_group_name
+  route53_health_check_api_id   = dependency.api.outputs.route53_health_check_api_id
+
+  s3_scan_object_error_threshold = "1"
+  scan_files_api_error_threshold = "1"  
 }
 
 include {

--- a/terragrunt/env/staging/alarms/terragrunt.hcl
+++ b/terragrunt/env/staging/alarms/terragrunt.hcl
@@ -3,7 +3,7 @@ terraform {
 }
 
 dependencies {
-  paths = ["../api"]
+  paths = ["../api, "../s3_scan_object"]
 }
 
 dependency "api" {
@@ -12,12 +12,28 @@ dependency "api" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
+    function_log_group_name     = "/var/lambda/scan-files-api"
     route53_health_check_api_id = ""
   }
 }
 
+dependency "s3_scan_object" {
+  config_path = "../s3_scan_object"
+
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
+  mock_outputs_merge_strategy_with_state  = "shallow"
+  mock_outputs = {
+    function_log_group_name = "/var/lambda/s3-scan-object"
+  }
+}
+
 inputs = {
-  route53_health_check_api_id = dependency.api.outputs.route53_health_check_api_id
+  s3_scan_object_log_group_name = dependency.s3_scan_object.outputs.function_log_group_name
+  scan_files_api_log_group_name = dependency.api.outputs.function_log_group_name
+  route53_health_check_api_id   = dependency.api.outputs.route53_health_check_api_id
+
+  s3_scan_object_error_threshold = "1"
+  scan_files_api_error_threshold = "1"
 }
 
 include {

--- a/terragrunt/env/staging/alarms/terragrunt.hcl
+++ b/terragrunt/env/staging/alarms/terragrunt.hcl
@@ -3,7 +3,7 @@ terraform {
 }
 
 dependencies {
-  paths = ["../api, "../s3_scan_object"]
+  paths = ["../api", "../s3_scan_object"]
 }
 
 dependency "api" {


### PR DESCRIPTION
# Summary
Add alarms for the API and S3 scan object log groups that will post
to the Slack ops channels when `ERROR` severity messages are logged.

# Related
* cds-snc/forms-terraform#224