### PR TITLE
refactor: move custom logging setup into middleware

### DIFF
--- a/api/api_gateway/custom_middleware.py
+++ b/api/api_gateway/custom_middleware.py
@@ -23,6 +23,8 @@ async def log_requests(request: Request, call_next):
     if "aws.context" not in request.scope:
         request.scope["aws.context"] = types.SimpleNamespace()
         request.scope["aws.context"].logger = CustomLogger("scan-files", None)
+    else:
+        request.scope["aws.context"].logger = CustomLogger("scan-files", request.scope["aws.context"].scanning_request_id)
 
     log = request.scope["aws.context"].logger.log
     log.info(f"start request path={request.url.path}")

--- a/api/main.py
+++ b/api/main.py
@@ -42,7 +42,7 @@ def handler(event, context):
             else context.aws_request_id
         )
 
-        context.logger = CustomLogger(context.aws_request_id, scanning_request_id)
+        context.scanning_request_id = scanning_request_id
         asgi_handler = Mangum(app)
         response = asgi_handler(event, context)
         return response


### PR DESCRIPTION
Potential conflict with either mangum or the metrics handler so moving the setup into the middleware to ensure it's only setup at the request level vs handler.