### PR TITLE
fix: full terraform apply in Staging

### DIFF
--- a/.github/workflows/tf_apply_staging.yml
+++ b/.github/workflows/tf_apply_staging.yml
@@ -36,26 +36,6 @@ jobs:
       - name: setup terraform tools
         uses: cds-snc/terraform-tools-setup@v1
 
-      - uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721 # tag=v2.10.2
-        id: filter
-        with:
-          filters: |
-            alarms:
-              - 'terragrunt/aws/alarms/**'
-              - 'terragrunt/env/staging/alarms/**'
-            api:
-              - 'terragrunt/aws/api/**'
-              - 'terragrunt/env/staging/api/**'
-            hosted_zone:
-              - 'terragrunt/aws/hosted_zone/**'
-              - 'terragrunt/env/staging/hosted_zone/**'
-            integration_test:
-              - 'terragrunt/aws/integration_test/**'
-              - 'terragrunt/env/staging/integration_test/**'
-            s3_scan_object:
-              - 'terragrunt/aws/s3_scan_object/**'
-              - 'terragrunt/env/staging/s3_scan_object/**'
-
       - name: configure aws credentials using OIDC
         uses: aws-actions/configure-aws-credentials@05b148adc31e091bafbaf404f745055d4d3bc9d2 # tag=v1.6.1
         with:
@@ -64,31 +44,21 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Apply hosted_zone
-        if: ${{ steps.filter.outputs.hosted_zone == 'true' }}
         working-directory: terragrunt/env/staging/hosted_zone
-        run: |
-          terragrunt apply --terragrunt-non-interactive -auto-approve
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve
 
       - name: Apply integration_test
-        if: ${{ steps.filter.outputs.integration_test == 'true' }}
         working-directory: terragrunt/env/staging/integration_test
-        run: |
-          terragrunt apply --terragrunt-non-interactive -auto-approve
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve
 
       - name: Apply api
-        if: ${{ steps.filter.outputs.api == 'true' }}
         working-directory: terragrunt/env/staging/api
-        run: |
-          terragrunt apply --terragrunt-non-interactive -auto-approve
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve
 
       - name: Apply s3_scan_object
-        if: ${{ steps.filter.outputs.s3_scan_object == 'true' }}
         working-directory: terragrunt/env/staging/s3_scan_object
-        run: |
-          terragrunt apply --terragrunt-non-interactive -auto-approve
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve
 
       - name: Apply alarms
-        if: ${{ steps.filter.outputs.alarms == 'true' }}
         working-directory: terragrunt/env/staging/alarms
-        run: |
-          terragrunt apply --terragrunt-non-interactive -auto-approve
+        run: terragrunt apply --terragrunt-non-interactive -auto-approve

--- a/terragrunt/aws/api/outputs.tf
+++ b/terragrunt/aws/api/outputs.tf
@@ -15,7 +15,7 @@ output "function_arn" {
 }
 
 output "function_log_group_name" {
-  value = "/var/lambda/${module.api.function_name}"
+  value = "/aws/lambda/${module.api.function_name}"
 }
 
 output "function_name" {

--- a/terragrunt/aws/s3_scan_object/outputs.tf
+++ b/terragrunt/aws/s3_scan_object/outputs.tf
@@ -1,3 +1,3 @@
 output "function_log_group_name" {
-  value = "/var/lambda/${module.s3_scan_object.function_name}"
+  value = "/aws/lambda/${module.s3_scan_object.function_name}"
 }

--- a/terragrunt/env/production/alarms/terragrunt.hcl
+++ b/terragrunt/env/production/alarms/terragrunt.hcl
@@ -12,7 +12,7 @@ dependency "api" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
-    function_log_group_name     = "/var/lambda/scan-files-api"
+    function_log_group_name     = "/aws/lambda/scan-files-api"
     route53_health_check_api_id = ""
   }
 }
@@ -23,7 +23,7 @@ dependency "s3_scan_object" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
-    function_log_group_name = "/var/lambda/s3-scan-object"
+    function_log_group_name = "/aws/lambda/s3-scan-object"
   }
 }
 

--- a/terragrunt/env/staging/alarms/terragrunt.hcl
+++ b/terragrunt/env/staging/alarms/terragrunt.hcl
@@ -12,7 +12,7 @@ dependency "api" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
-    function_log_group_name     = "/var/lambda/scan-files-api"
+    function_log_group_name     = "/aws/lambda/scan-files-api"
     route53_health_check_api_id = ""
   }
 }
@@ -23,7 +23,7 @@ dependency "s3_scan_object" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
-    function_log_group_name = "/var/lambda/s3-scan-object"
+    function_log_group_name = "/aws/lambda/s3-scan-object"
   }
 }
 


### PR DESCRIPTION
# Summary
Update the Staging `terraform apply` to always run against
all modules.  The reason for this change is because it was allowing
for scenarios where ClickOps changes were not getting reset
since there were no changes to the affected modules.

Although this increases blast radius potential for changes,
it does reduce the potential for drift and matches the Staging
Terraform plan/apply results to how Production behaves.

Also fixes the CloudWatch alarm log group names.

# Related
* #190 
* cds-snc/forms-terraform#224