### PR TITLE
fix: scan verdict CloudWatch log filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,7 +102,7 @@ celerybeat.pid
 *.sage.py
 
 # Environments
-.env
+.env*
 .venv
 # env/
 venv/

--- a/terragrunt/aws/alarms/alarms.tf
+++ b/terragrunt/aws/alarms/alarms.tf
@@ -59,7 +59,7 @@ resource "aws_cloudwatch_metric_alarm" "scan_files_api_error" {
 
 resource "aws_cloudwatch_log_metric_filter" "scan_verdict_suspicious" {
   name           = local.scan_verdict_suspicious
-  pattern        = "suspicious? malicious? unknown? unable_to_scan?"
+  pattern        = "?suspicious ?malicious ?unknown ?unable_to_scan"
   log_group_name = var.scan_files_api_log_group_name
 
   metric_transformation {


### PR DESCRIPTION
# Summary
Fix the scan verdict suspicious log filter to have the `?`
optional character in the correct spot.

# :warning: Note
This was applied locally to test.