### PR TITLE
fix: use log to retrieve scanning id when needed

### DIFF
--- a/api/api_gateway/custom_middleware.py
+++ b/api/api_gateway/custom_middleware.py
@@ -3,7 +3,6 @@ from logger import log
 from os import environ
 from uuid import uuid4
 import time
-import types
 
 
 API_AUTH_TOKEN = environ.get("API_AUTH_TOKEN", uuid4())
@@ -18,13 +17,6 @@ async def add_security_headers(request: Request, call_next):
 
 
 async def log_requests(request: Request, call_next):
-
-    # This should only happen when the app is not running in Lambda
-    if "aws.context" not in request.scope:
-        request.scope["aws.context"] = types.SimpleNamespace()
-        random_id = str(uuid4())
-        request.scope["aws.context"].scanning_request_id = random_id
-        log.set_correlation_id(random_id)
 
     log.info(f"start request path={request.url.path}")
     start_time = time.time()

--- a/api/api_gateway/routers/clamav.py
+++ b/api/api_gateway/routers/clamav.py
@@ -77,7 +77,7 @@ def start_clamav_scan_from_s3(
         session.commit()
 
         launch_background_scan(
-            request.scope["aws.context"].scanning_request_id,
+            log.get_correlation_id(),
             s3_key,
             scan.id,
             session=session,

--- a/api/main.py
+++ b/api/main.py
@@ -37,8 +37,7 @@ def handler(event, context):
     ):
         # Assume it is a request to the lambda function url
         if "X-Scanning-Request-Id" in event["headers"]:
-            context.scanning_request_id = event["headers"]["X-Scanning-Request-Id"]
-            log.set_correlation_id(context.scanning_request_id)
+            log.set_correlation_id(event["headers"]["X-Scanning-Request-Id"])
 
         asgi_handler = Mangum(app)
         response = asgi_handler(event, context)
@@ -57,7 +56,7 @@ def handler(event, context):
         return resubmit_stale_scans()
 
     elif event.get("task", "") == CLAMAV_LAMBDA_SCAN_TASK_NAME:
-        log.set_correlation_id(event.get("scanning_request_id"))
+        log.set_correlation_id(event.get("scanning_request_id", None))
         return clamav_launch_scan(
             file_path=event.get("file_path"),
             scan_id=event.get("scan_id"),


### PR DESCRIPTION
Taking advantage of the logger always containing the scan id, so it's no longer necessary to inject into the context object.