### PR TITLE
fix: use `correlation_id` in the S3 scan object logs

### DIFF
--- a/module/s3-scan-object/app.js
+++ b/module/s3-scan-object/app.js
@@ -35,7 +35,7 @@ const logger = pino({ level: LOGGING_LEVEL }, pinoLambdaDestination());
 const withRequest = lambdaRequestTracker({
   requestMixin: (event) => {
     return {
-      requestId: event.RequestId ? event.RequestId : undefined,
+      correlation_id: event.RequestId ? event.RequestId : undefined,
     };
   },
 });


### PR DESCRIPTION
# Summary
Update to use `correlation_id` in the S3 scan object logs to be consistent
with how request ID is being logged by the API.

# Related
* #196 