### PR TITLE
feat: send correlation id back when reporting to sns

### DIFF
--- a/api/clamav_scanner/scan.py
+++ b/api/clamav_scanner/scan.py
@@ -26,7 +26,9 @@ def sns_scan_results(sns_client, scan, sns_arn, scan_signature, file_path, aws_a
         AV_STATUS_METADATA: scan.verdict,
         AV_TIMESTAMP_METADATA: scan.completed.isoformat(),
         "aws_account": aws_account,
-        "correlation_id": log.get_correlation_id() if log.get_correlation_id() else "None"
+        "correlation_id": log.get_correlation_id()
+        if log.get_correlation_id()
+        else "None",
     }
 
     log.info("Publishing to sns arn: %s; message: %s" % (sns_arn, str(message)))
@@ -46,7 +48,10 @@ def sns_scan_results(sns_client, scan, sns_arn, scan_signature, file_path, aws_a
                 "StringValue": scan_signature,
             },
             "aws-account": {"DataType": "String", "StringValue": aws_account},
-            "correlation-id": {"DataType": "String", "StringValue": message["correlation_id"]},
+            "correlation-id": {
+                "DataType": "String",
+                "StringValue": message["correlation_id"],
+            },
         },
     )
 

--- a/api/clamav_scanner/scan.py
+++ b/api/clamav_scanner/scan.py
@@ -26,6 +26,7 @@ def sns_scan_results(sns_client, scan, sns_arn, scan_signature, file_path, aws_a
         AV_STATUS_METADATA: scan.verdict,
         AV_TIMESTAMP_METADATA: scan.completed.isoformat(),
         "aws_account": aws_account,
+        "correlation_id": log.get_correlation_id() if log.get_correlation_id() else "None"
     }
 
     log.info("Publishing to sns arn: %s; message: %s" % (sns_arn, str(message)))
@@ -45,6 +46,7 @@ def sns_scan_results(sns_client, scan, sns_arn, scan_signature, file_path, aws_a
                 "StringValue": scan_signature,
             },
             "aws-account": {"DataType": "String", "StringValue": aws_account},
+            "correlation-id": {"DataType": "String", "StringValue": message["correlation_id"]},
         },
     )
 

--- a/api/tests/clamav/test_scan.py
+++ b/api/tests/clamav/test_scan.py
@@ -102,6 +102,6 @@ def test_sns_scan_results_error(mock_db_session, mock_aws_session, mock_log, ses
             "av-status": {"DataType": "String", "StringValue": "error"},
             "av-signature": {"DataType": "String", "StringValue": "OK"},
             "aws-account": {"DataType": "String", "StringValue": "210987654321"},
-            "correlation-id": {"DataType": "String", "StringValue": "random-id"}
+            "correlation-id": {"DataType": "String", "StringValue": "random-id"},
         },
     )


### PR DESCRIPTION
Send the correlation id back via SNS so that the last step of the file scanning process can be traced.