### PR TITLE
fix: swagger docs csp violations

### DIFF
--- a/api/api_gateway/custom_middleware.py
+++ b/api/api_gateway/custom_middleware.py
@@ -13,6 +13,10 @@ async def add_security_headers(request: Request, call_next):
     response.headers[
         "Strict-Transport-Security"
     ] = "max-age=63072000; includeSubDomains; preload"
+
+    response.headers[
+        "Content-Security-Policy"
+    ] = "report-uri https://csp-report-to.security.cdssandbox.xyz/report; default-src 'none'; script-src 'self'; script-src-elem https://cdn.jsdelivr.net/npm/swagger-ui-dist@4/ 'sha256-QOOQu4W1oxGqd2nbXbxiA1Di6OHQOLQD+o+G9oWL8YY='; connect-src 'self'; img-src 'self' https://fastapi.tiangolo.com/img/ data: 'unsafe-eval'; style-src 'self'; style-src-elem 'self' https://cdn.jsdelivr.net/npm/swagger-ui-dist@4/; frame-ancestors 'self'; form-action 'self';"
     return response
 
 

--- a/api/tests/api_gateway/test_api.py
+++ b/api/tests/api_gateway/test_api.py
@@ -70,10 +70,15 @@ def test_api_docs_enabled_via_environ():
     assert response.status_code == 200
 
 
-def test_hsts_in_response(hsts_middleware_client):
+def test_security_headers_in_response(hsts_middleware_client):
     response = hsts_middleware_client.get("/version")
     assert response.status_code == 200
     assert (
         response.headers["Strict-Transport-Security"]
         == "max-age=63072000; includeSubDomains; preload"
+    )
+
+    assert (
+        response.headers["Content-Security-Policy"]
+        == "report-uri https://csp-report-to.security.cdssandbox.xyz/report; default-src 'none'; script-src 'self'; script-src-elem https://cdn.jsdelivr.net/npm/swagger-ui-dist@4/ 'sha256-QOOQu4W1oxGqd2nbXbxiA1Di6OHQOLQD+o+G9oWL8YY='; connect-src 'self'; img-src 'self' https://fastapi.tiangolo.com/img/ data: 'unsafe-eval'; style-src 'self'; style-src-elem 'self' https://cdn.jsdelivr.net/npm/swagger-ui-dist@4/; frame-ancestors 'self'; form-action 'self';"
     )

--- a/terragrunt/aws/api/cloudfront.tf
+++ b/terragrunt/aws/api/cloudfront.tf
@@ -92,7 +92,7 @@ resource "aws_cloudfront_response_headers_policy" "security_headers_policy_api" 
     }
     content_security_policy {
       content_security_policy = "report-uri https://csp-report-to.security.cdssandbox.xyz/report; default-src 'none'; script-src 'self'; connect-src 'self'; img-src 'self'; style-src 'self'; frame-ancestors 'self'; form-action 'self';"
-      override                = true
+      override                = false
     }
     referrer_policy {
       override        = true


### PR DESCRIPTION
currently unable to view the /docs endpoint due to the recently introduced CSP. Unfortunately setting `data: 'unsafe-eval'` is required due to the swagger docs using inline svg images. Since this app is api driven and isn't serving user content the risk is low.