### PR TITLE
fix: integration test and async event timeout

### DIFF
--- a/.github/workflows/integration_test_production.yml
+++ b/.github/workflows/integration_test_production.yml
@@ -87,7 +87,3 @@ jobs:
         run: |
           json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":red: Integration test failed: <https://github.com/cds-snc/scan-files/actions/workflows/integration_test_production.yml|Integration test production>"}}]}'
           curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.SCAN_FILES_PROD_OPS_WEBHOOK }}
-
-      - name: Remove test file
-        if: always()
-        run: aws s3 rm s3://${{ env.BUCKET_NAME }}/${{ env.FILENAME }}

--- a/.github/workflows/integration_test_staging.yml
+++ b/.github/workflows/integration_test_staging.yml
@@ -87,7 +87,3 @@ jobs:
         run: |
           json='{"blocks":[{"type":"section","text":{"type":"mrkdwn","text":":red: Integration test failed: <https://github.com/cds-snc/scan-files/actions/workflows/integration_test_staging.yml|Integration test staging>"}}]}'
           curl -X POST -H 'Content-type: application/json' --data "$json" ${{ secrets.SCAN_FILES_STAGING_OPS_WEBHOOK }}
-
-      - name: Remove test file
-        if: always()
-        run: aws s3 rm s3://${{ env.BUCKET_NAME }}/${{ env.FILENAME }}

--- a/terragrunt/aws/s3_scan_object/lambda.tf
+++ b/terragrunt/aws/s3_scan_object/lambda.tf
@@ -5,7 +5,7 @@ module "s3_scan_object" {
   image_uri = "${aws_ecr_repository.s3_scan_object.repository_url}:latest"
   ecr_arn   = aws_ecr_repository.s3_scan_object.arn
   memory    = 512
-  timeout   = 15
+  timeout   = 60
 
   reserved_concurrent_executions = 3
 


### PR DESCRIPTION
# Summary
Update the timeout on the `s3-scan-object` function so that it
can handle cases where the API needs to start the ClamAV daemon.

Perviously, the S3 event triggering the lambda function could timeout
if a new API function had just been deployed.  Since the S3 event
trigger is async, this was [causing multiple retries of the same
S3 event](https://docs.aws.amazon.com/lambda/latest/dg/invocation-async.html#invocation-async-errors), which would fail once the workflow deleted the test file.

To be on the safe side, we'll rely on S3 bucket expiration rules to
remove the integration test file so that multiple retries of an S3
event don't lead to errors being logged.

# Related
* Closes #212 
* [AWS docs: Configuring error handling for asynchronous invocation](https://docs.aws.amazon.com/lambda/latest/dg/invocation-async.html#invocation-async-errors)