### PR TITLE
fix: increase `api` CloudFront read timeout

### DIFF
--- a/terragrunt/aws/api/cloudfront.tf
+++ b/terragrunt/aws/api/cloudfront.tf
@@ -11,6 +11,7 @@ resource "aws_cloudfront_distribution" "scan_files_api" {
     custom_origin_config {
       http_port              = 80
       https_port             = 443
+      origin_read_timeout    = 60
       origin_protocol_policy = "https-only"
       origin_ssl_protocols   = ["TLSv1.2"]
     }


### PR DESCRIPTION
# Summary
Update the `api` CloudFront origin config to wait for 60 seconds
before responding with a 504 gateway timeout.

This is required because it can take over 30 seconds (default read
timeout) when a new `api` function execution environment is created
and the ClamAV daemon needs to be started.