### PR TITLE
chore: update to use consistent AWS org ID

### DIFF
--- a/.github/workflows/tf_apply_staging.yml
+++ b/.github/workflows/tf_apply_staging.yml
@@ -13,7 +13,7 @@ env:
   TERRAFORM_VERSION: 1.0.3
   TERRAGRUNT_VERSION: 0.38.4
   TF_VAR_api_auth_token: ${{ secrets.STAGING_API_AUTH_TOKEN }}
-  TF_VAR_aws_org_id: ${{ secrets.STAGING_AWS_ORG_ID }}
+  TF_VAR_aws_org_id: ${{ secrets.AWS_ORG_ID }}
   TF_VAR_rds_password: ${{ secrets.STAGING_RDS_PASSWORD }}
   TF_VAR_slack_webhook_url: ${{ secrets.SCAN_FILES_STAGING_OPS_WEBHOOK }}
   AWS_REGION: ca-central-1

--- a/.github/workflows/tf_plan_staging.yml
+++ b/.github/workflows/tf_plan_staging.yml
@@ -14,7 +14,7 @@ env:
   TERRAGRUNT_VERSION: 0.38.4
   CONFTEST_VERSION: 0.27.0
   TF_VAR_api_auth_token: ${{ secrets.STAGING_API_AUTH_TOKEN }}
-  TF_VAR_aws_org_id: ${{ secrets.STAGING_AWS_ORG_ID }}
+  TF_VAR_aws_org_id: ${{ secrets.AWS_ORG_ID }}
   TF_VAR_rds_password: ${{ secrets.STAGING_RDS_PASSWORD }}
   TF_VAR_slack_webhook_url: ${{ secrets.SCAN_FILES_STAGING_OPS_WEBHOOK }}
 


### PR DESCRIPTION
# Summary
Now that the production account has migrated to the same
AWS organization, we no longer need environment specific
org IDs.