### PR TITLE
fix: allow use from new and old AWS org accounts

### DIFF
--- a/.github/workflows/tf_apply_production.yml
+++ b/.github/workflows/tf_apply_production.yml
@@ -13,6 +13,7 @@ env:
   TERRAGRUNT_VERSION: 0.38.4
   TF_VAR_api_auth_token: ${{ secrets.PRODUCTION_API_AUTH_TOKEN }}
   TF_VAR_aws_org_id: ${{ secrets.AWS_ORG_ID }}
+  TF_VAR_aws_org_id_old: ${{ secrets.AWS_ORG_ID_OLD }}
   TF_VAR_rds_password: ${{ secrets.PRODUCTION_RDS_PASSWORD }}
   TF_VAR_slack_webhook_url: ${{ secrets.SCAN_FILES_PROD_OPS_WEBHOOK }}
   AWS_REGION: ca-central-1

--- a/.github/workflows/tf_apply_staging.yml
+++ b/.github/workflows/tf_apply_staging.yml
@@ -14,6 +14,7 @@ env:
   TERRAGRUNT_VERSION: 0.38.4
   TF_VAR_api_auth_token: ${{ secrets.STAGING_API_AUTH_TOKEN }}
   TF_VAR_aws_org_id: ${{ secrets.AWS_ORG_ID }}
+  TF_VAR_aws_org_id_old: ${{ secrets.AWS_ORG_ID_OLD }}
   TF_VAR_rds_password: ${{ secrets.STAGING_RDS_PASSWORD }}
   TF_VAR_slack_webhook_url: ${{ secrets.SCAN_FILES_STAGING_OPS_WEBHOOK }}
   AWS_REGION: ca-central-1

--- a/.github/workflows/tf_plan_production.yml
+++ b/.github/workflows/tf_plan_production.yml
@@ -14,6 +14,7 @@ env:
   CONFTEST_VERSION: 0.27.0
   TF_VAR_api_auth_token: ${{ secrets.PRODUCTION_API_AUTH_TOKEN }}
   TF_VAR_aws_org_id: ${{ secrets.AWS_ORG_ID }}
+  TF_VAR_aws_org_id_old: ${{ secrets.AWS_ORG_ID_OLD }}
   TF_VAR_rds_password: ${{ secrets.PRODUCTION_RDS_PASSWORD }}
   TF_VAR_slack_webhook_url: ${{ secrets.SCAN_FILES_PROD_OPS_WEBHOOK }}
 

--- a/.github/workflows/tf_plan_staging.yml
+++ b/.github/workflows/tf_plan_staging.yml
@@ -15,6 +15,7 @@ env:
   CONFTEST_VERSION: 0.27.0
   TF_VAR_api_auth_token: ${{ secrets.STAGING_API_AUTH_TOKEN }}
   TF_VAR_aws_org_id: ${{ secrets.AWS_ORG_ID }}
+  TF_VAR_aws_org_id_old: ${{ secrets.AWS_ORG_ID_OLD }}
   TF_VAR_rds_password: ${{ secrets.STAGING_RDS_PASSWORD }}
   TF_VAR_slack_webhook_url: ${{ secrets.SCAN_FILES_STAGING_OPS_WEBHOOK }}
 

--- a/terragrunt/aws/api/iam.tf
+++ b/terragrunt/aws/api/iam.tf
@@ -152,8 +152,8 @@ data "aws_iam_policy_document" "api_assume_cross_account" {
       "arn:aws:iam::*:role/ScanFilesGetObjects"
     ]
     condition {
-      test     = "StringEquals"
-      values   = [var.aws_org_id]
+      test     = "ForAnyValue:StringEquals"
+      values   = [var.aws_org_id, var.aws_org_id_old]
       variable = "aws:PrincipalOrgID"
     }
   }

--- a/terragrunt/aws/s3_scan_object/lambda.tf
+++ b/terragrunt/aws/s3_scan_object/lambda.tf
@@ -48,8 +48,8 @@ data "aws_iam_policy_document" "assume_cross_account" {
       "arn:aws:iam::*:role/ScanFilesGetObjects"
     ]
     condition {
-      test     = "StringEquals"
-      values   = [var.aws_org_id]
+      test     = "ForAnyValue:StringEquals"
+      values   = [var.aws_org_id, var.aws_org_id_old]
       variable = "aws:PrincipalOrgID"
     }
   }
@@ -61,4 +61,12 @@ resource "aws_lambda_permission" "s3_scan_object_org_account_execute" {
   function_name    = module.s3_scan_object.function_name
   principal        = "*"
   principal_org_id = var.aws_org_id
+}
+
+resource "aws_lambda_permission" "s3_scan_object_old_org_account_execute" {
+  statement_id     = "AllowExecutionFromOldOrgAccounts"
+  action           = "lambda:InvokeFunction"
+  function_name    = module.s3_scan_object.function_name
+  principal        = "*"
+  principal_org_id = var.aws_org_id_old
 }

--- a/terragrunt/env/common/common_variables.tf
+++ b/terragrunt/env/common/common_variables.tf
@@ -9,6 +9,12 @@ variable "aws_org_id" {
   sensitive   = true
 }
 
+variable "aws_org_id_old" {
+  description = "(Required) The old AWS org account ID.  Used to limit which roles the API can assume and will be removed once all accounts are migrated."
+  type        = string
+  sensitive   = true
+}
+
 variable "cbs_satellite_bucket_name" {
   description = "(Required) Name of the Cloud Based Sensor S3 satellite bucket"
   type        = string


### PR DESCRIPTION
# Summary
Update Scan Files to allow it to be used from accounts in both
the new and old AWS org.  Once all accounts are fully migrated
to the new org, we can remove the `aws_org_id_old` variable.