### PR TITLE
fix: database connection settings

### DIFF
--- a/api/database/db.py
+++ b/api/database/db.py
@@ -8,7 +8,14 @@ if os.environ.get("CI"):
 else:
     connection_string = os.environ.get("SQLALCHEMY_DATABASE_URI")
 # Timeout is set to 10 seconds
-db_engine = create_engine(connection_string, connect_args={"connect_timeout": 10})
+db_engine = create_engine(
+    connection_string,
+    connect_args={"connect_timeout": 10},
+    pool_size=1,
+    pool_pre_ping=True,  # Check that a connection is still active before attempting to use
+    pool_recycle=1500,  # Prune connections older than 25 minutes (RDS Proxy has a timeout of 30 minutes)
+    pool_use_lifo=True,  # Re-use last connection used (allows server-side timeouts to remove unused connections)
+)
 db_session = sessionmaker(bind=db_engine)
 
 


### PR DESCRIPTION
# Summary

Update the database connection settings as follows:

1. Explicitly set a pool size of 1 since we use RDS Proxy
which handles our connection pooling.

2. Set pessimistic connection testing with `pool_pre_ping` to check
that a connection is still valid before it is used.

3. Set opptimistic connection testing by pruning any connection that
is older that 25 minutes (since the RDS proxy connection timeout is
30 minutes).

4. Always re-use the last connection used, whic allows the RDS proxy
connection settings to be applied.

# Related
* Closes #226 