### PR TITLE
fix: mount ClamAV defs in API container

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       context: ../api/
     volumes:
       - ../api:/function
+      - ../api/clamav_defs:/tmp/clamav
     environment:
       <<: [*db-connection-strings, *api_envs]
     ports:

--- a/api/requirements_dev.txt
+++ b/api/requirements_dev.txt
@@ -5,5 +5,5 @@ factory-boy==3.2.0
 flake8==3.9.2
 locust==2.1.0
 pytest==6.2.4
-requests==2.25.1
+requests==2.28.1
 uvicorn==0.14.0


### PR DESCRIPTION
# Summary
Update the `api` service to mount the ClamAV virus definitions
in the expected location.  This makes it easier to get the
local dev environment setup.

Also updates a dev dependency to fix a Python dependency
resolution issue.
