### PR TITLE
feat: tighten WAF ACL rules

### DIFF
--- a/terragrunt/aws/api/route53.tf
+++ b/terragrunt/aws/api/route53.tf
@@ -17,7 +17,7 @@ resource "aws_route53_health_check" "scan_files_A" {
   resource_path     = "/healthcheck"
   failure_threshold = "5"
   request_interval  = "30"
-  regions           = ["ca-central-1", "us-east-1", "us-west-1"]
+  regions           = ["us-east-1", "us-west-1", "us-west-2"]
 
   tags = {
     CostCentre = var.billing_code

--- a/terragrunt/aws/api/route53.tf
+++ b/terragrunt/aws/api/route53.tf
@@ -17,6 +17,7 @@ resource "aws_route53_health_check" "scan_files_A" {
   resource_path     = "/healthcheck"
   failure_threshold = "5"
   request_interval  = "30"
+  regions           = ["ca-central-1", "us-east-1", "us-west-1"]
 
   tags = {
     CostCentre = var.billing_code


### PR DESCRIPTION
# Summary
Update the WAF ACL to block the following traffic:

- Any requests from outside North America.
- Any requests that do not match a valid API path.
- More than 2,000 requests in a 5 minute period from an IP address.

Also updates Route53 health checks to only run from North
American regions so they are not blocked by the WAF rules.

# Related
* #239 