### PR TITLE
feat: add Ops CloudWatch dashboard

### DIFF
--- a/terragrunt/aws/alarms/dashboard.tf
+++ b/terragrunt/aws/alarms/dashboard.tf
@@ -1,0 +1,13 @@
+resource "aws_cloudwatch_dashboard" "ops" {
+  dashboard_name = "Ops"
+  dashboard_body = data.template_file.ops_dashboard.rendered
+}
+
+data "template_file" "ops_dashboard" {
+  template = file("${path.module}/dashboards/ops.json")
+  vars = {
+    account_id                     = var.account_id
+    api_cloudfront_distribution_id = var.api_cloudfront_distribution_id
+    health_check_id                = var.route53_health_check_api_id
+  }
+}

--- a/terragrunt/aws/alarms/dashboards/ops.json
+++ b/terragrunt/aws/alarms/dashboards/ops.json
@@ -1,0 +1,164 @@
+{
+    "widgets": [
+        {
+            "height": 4,
+            "width": 6,
+            "y": 4,
+            "x": 18,
+            "type": "alarm",
+            "properties": {
+                "title": "Alarms",
+                "alarms": [
+                    "arn:aws:cloudwatch:ca-central-1:${account_id}:alarm:ErrorLoggedAPI",
+                    "arn:aws:cloudwatch:ca-central-1:${account_id}:alarm:ErrorLoggedS3ScanObject",
+                    "arn:aws:cloudwatch:ca-central-1:${account_id}:alarm:ScanVerdictSuspicious"
+                ]
+            }
+        },
+        {
+            "height": 16,
+            "width": 18,
+            "y": 4,
+            "x": 0,
+            "type": "explorer",
+            "properties": {
+                "metrics": [
+                    {
+                        "metricName": "Invocations",
+                        "resourceType": "AWS::Lambda::Function",
+                        "stat": "Sum"
+                    },
+                    {
+                        "metricName": "Duration",
+                        "resourceType": "AWS::Lambda::Function",
+                        "stat": "Average"
+                    },
+                    {
+                        "metricName": "Errors",
+                        "resourceType": "AWS::Lambda::Function",
+                        "stat": "Sum"
+                    },
+                    {
+                        "metricName": "ConcurrentExecutions",
+                        "resourceType": "AWS::Lambda::Function",
+                        "stat": "Maximum"
+                    }
+                ],
+                "labels": [
+                    {
+                        "key": "FunctionName",
+                        "value": "scan-files-api"
+                    },
+                    {
+                        "key": "FunctionName",
+                        "value": "s3-scan-object"
+                    },
+                    {
+                        "key": "FunctionName",
+                        "value": "s3-scan-object-integration-test"
+                    }
+                ],
+                "widgetOptions": {
+                    "legend": {
+                        "position": "bottom"
+                    },
+                    "view": "timeSeries",
+                    "stacked": false,
+                    "rowsPerPage": 5,
+                    "widgetsPerRow": 2
+                },
+                "period": 300,
+                "splitBy": "",
+                "region": "ca-central-1",
+                "title": "Lambda"
+            }
+        },
+        {
+            "height": 4,
+            "width": 18,
+            "y": 0,
+            "x": 0,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ "AWS/CloudFront", "Requests", "Region", "Global", "DistributionId", "${api_cloudfront_distribution_id}", { "region": "us-east-1" } ],
+                    [ ".", "4xxErrorRate", ".", ".", ".", ".", { "region": "us-east-1" } ],
+                    [ ".", "5xxErrorRate", ".", ".", ".", ".", { "region": "us-east-1" } ],
+                    [ ".", "TotalErrorRate", ".", ".", ".", ".", { "region": "us-east-1" } ],
+                    [ ".", "BytesUploaded", ".", ".", ".", ".", { "region": "us-east-1" } ],
+                    [ ".", "BytesDownloaded", ".", ".", ".", ".", { "region": "us-east-1" } ]
+                ],
+                "view": "singleValue",
+                "region": "ca-central-1",
+                "stacked": true,
+                "title": "Cloudfront",
+                "period": 300,
+                "stat": "Average"
+            }
+        },
+        {
+            "height": 6,
+            "width": 6,
+            "y": 8,
+            "x": 18,
+            "type": "metric",
+            "properties": {
+                "metrics": [
+                    [ "AWS/WAFV2", "AllowedRequests", "WebACL", "api_waf", "Rule", "ALL", { "region": "us-east-1", "color": "#2ca02c" } ],
+                    [ ".", "BlockedRequests", ".", ".", ".", ".", { "region": "us-east-1", "color": "#d62728" } ]
+                ],
+                "sparkline": true,
+                "view": "timeSeries",
+                "region": "ca-central-1",
+                "stacked": true,
+                "title": "Firewall",
+                "period": 300,
+                "stat": "Sum"
+            }
+        },
+        {
+            "height": 4,
+            "width": 6,
+            "y": 0,
+            "x": 18,
+            "type": "metric",
+            "properties": {
+                "view": "singleValue",
+                "metrics": [
+                    [ "AWS/Route53", "HealthCheckPercentageHealthy", "HealthCheckId", "${health_check_id}", { "region": "us-east-1" } ]
+                ],
+                "region": "ca-central-1",
+                "stacked": false,
+                "title": "Route53"
+            }
+        },
+        {
+            "height": 6,
+            "width": 12,
+            "y": 20,
+            "x": 0,
+            "type": "log",
+            "properties": {
+                "query": "SOURCE '/aws/lambda/scan-files-api' | fields @timestamp, @message, @logStream\n| filter @message like /ERROR/\n| sort @timestamp desc\n| limit 20\n",
+                "region": "ca-central-1",
+                "stacked": false,
+                "view": "table",
+                "title": "Errors: API"
+            }
+        },
+        {
+            "height": 6,
+            "width": 12,
+            "y": 20,
+            "x": 12,
+            "type": "log",
+            "properties": {
+                "query": "SOURCE '/aws/lambda/s3-scan-object' | fields @timestamp, @message, @logStream\n| filter @message like /ERROR/\n| sort @timestamp desc\n| limit 20\n",
+                "region": "ca-central-1",
+                "stacked": false,
+                "view": "table",
+                "title": "Errors: S3 scan object"
+            }
+        }
+    ]
+}

--- a/terragrunt/aws/alarms/inputs.tf
+++ b/terragrunt/aws/alarms/inputs.tf
@@ -1,3 +1,8 @@
+variable "api_cloudfront_distribution_id" {
+  description = "ID of the API CloudFront distribution"
+  type        = string
+}
+
 variable "route53_health_check_api_id" {
   description = "ID of the API's Route53 health check"
   type        = string

--- a/terragrunt/aws/api/outputs.tf
+++ b/terragrunt/aws/api/outputs.tf
@@ -1,3 +1,7 @@
+output "api_cloudfront_distribution_id" {
+  value = aws_cloudfront_distribution.scan_files_api.id
+}
+
 output "vpc_id" {
   value = module.vpc.vpc_id
 }

--- a/terragrunt/env/production/alarms/terragrunt.hcl
+++ b/terragrunt/env/production/alarms/terragrunt.hcl
@@ -12,8 +12,9 @@ dependency "api" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
-    function_log_group_name     = "/aws/lambda/scan-files-api"
-    route53_health_check_api_id = ""
+    api_cloudfront_distribution_id = "cloudfront-distribution-id"
+    function_log_group_name        = "/aws/lambda/scan-files-api"
+    route53_health_check_api_id    = ""
   }
 }
 
@@ -28,9 +29,10 @@ dependency "s3_scan_object" {
 }
 
 inputs = {
-  s3_scan_object_log_group_name = dependency.s3_scan_object.outputs.function_log_group_name
-  scan_files_api_log_group_name = dependency.api.outputs.function_log_group_name
-  route53_health_check_api_id   = dependency.api.outputs.route53_health_check_api_id
+  s3_scan_object_log_group_name  = dependency.s3_scan_object.outputs.function_log_group_name
+  scan_files_api_log_group_name  = dependency.api.outputs.function_log_group_name
+  route53_health_check_api_id    = dependency.api.outputs.route53_health_check_api_id
+  api_cloudfront_distribution_id = dependency.api.outputs.api_cloudfront_distribution_id
 
   s3_scan_object_error_threshold                   = "1"
   scan_files_api_error_threshold                   = "1"

--- a/terragrunt/env/staging/alarms/terragrunt.hcl
+++ b/terragrunt/env/staging/alarms/terragrunt.hcl
@@ -12,8 +12,9 @@ dependency "api" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
-    function_log_group_name     = "/aws/lambda/scan-files-api"
-    route53_health_check_api_id = ""
+    api_cloudfront_distribution_id = "cloudfront-distribution-id"
+    function_log_group_name        = "/aws/lambda/scan-files-api"
+    route53_health_check_api_id    = ""
   }
 }
 
@@ -28,9 +29,10 @@ dependency "s3_scan_object" {
 }
 
 inputs = {
-  s3_scan_object_log_group_name = dependency.s3_scan_object.outputs.function_log_group_name
-  scan_files_api_log_group_name = dependency.api.outputs.function_log_group_name
-  route53_health_check_api_id   = dependency.api.outputs.route53_health_check_api_id
+  s3_scan_object_log_group_name  = dependency.s3_scan_object.outputs.function_log_group_name
+  scan_files_api_log_group_name  = dependency.api.outputs.function_log_group_name
+  route53_health_check_api_id    = dependency.api.outputs.route53_health_check_api_id
+  api_cloudfront_distribution_id = dependency.api.outputs.api_cloudfront_distribution_id
 
   s3_scan_object_error_threshold                   = "1"
   scan_files_api_error_threshold                   = "1"


### PR DESCRIPTION
# Summary
Add a dashboard that includes metrics for CloudFront,
Lambda, Firewall, CloudWatch Alarm status and any
recent errors logged.

# Related
* #234 