### PR TITLE
fix: create a new Athena `logs` workgroup

### DIFF
--- a/terragrunt/aws/alarms/athena.tf
+++ b/terragrunt/aws/alarms/athena.tf
@@ -11,15 +11,15 @@ resource "aws_athena_database" "logs" {
   }
 }
 
-resource "aws_athena_workgroup" "primary" {
-  name = "primary"
+resource "aws_athena_workgroup" "logs" {
+  name = "logs"
 
   configuration {
     enforce_workgroup_configuration    = true
     publish_cloudwatch_metrics_enabled = true
 
     result_configuration {
-      output_location = "s3://${module.athena_bucket.s3_bucket_id}"
+      output_location = "s3://${module.athena_bucket.s3_bucket_id}/logs/"
 
       encryption_configuration {
         encryption_option = "SSE_S3"
@@ -35,7 +35,7 @@ resource "aws_athena_workgroup" "primary" {
 
 resource "aws_athena_named_query" "waf_create_table" {
   name      = "WAF: create table"
-  workgroup = aws_athena_workgroup.primary.name
+  workgroup = aws_athena_workgroup.logs.name
   database  = aws_athena_database.logs.name
   query = templatefile("${path.module}/sql/athena_waf_create_table.sql",
     {
@@ -48,7 +48,7 @@ resource "aws_athena_named_query" "waf_create_table" {
 
 resource "aws_athena_named_query" "waf_blocked_requests" {
   name      = "WAF: blocked requests"
-  workgroup = aws_athena_workgroup.primary.name
+  workgroup = aws_athena_workgroup.logs.name
   database  = aws_athena_database.logs.name
   query = templatefile("${path.module}/sql/athena_waf_blocked_requests.sql",
     {
@@ -60,7 +60,7 @@ resource "aws_athena_named_query" "waf_blocked_requests" {
 
 resource "aws_athena_named_query" "waf_all_requests" {
   name      = "WAF: all requests"
-  workgroup = aws_athena_workgroup.primary.name
+  workgroup = aws_athena_workgroup.logs.name
   database  = aws_athena_database.logs.name
   query = templatefile("${path.module}/sql/athena_waf_all_requests.sql",
     {

--- a/terragrunt/env/staging/alarms/.terraform.lock.hcl
+++ b/terragrunt/env/staging/alarms/.terraform.lock.hcl
@@ -21,7 +21,7 @@ provider "registry.terraform.io/hashicorp/archive" {
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "4.22.0"
-  constraints = "~> 4.9"
+  constraints = ">= 4.9.0, ~> 4.9, < 5.0.0"
   hashes = [
     "h1:RxPzK6VFHz6qZMZUVhE03j9Cf5CvnLr14egtq5yxD1E=",
     "zh:299efb8ba733b7742f0ef1c5c5467819e0c7bf46264f5f36ba6b6674304a5244",
@@ -36,5 +36,22 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:d8a75ba36bf8b6f2e49be5682f48eccb6c667a4484afd676ae347213ae208622",
     "zh:dd7c419674a47e587dabe98b150a8f1f7e31c248c68e8bf5e9ca0a400b5e2c4e",
     "zh:fdeb6314a2ce97489bbbece59511f78306955e8a23b02cbd1485bd04185a3673",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/template" {
+  version = "2.2.0"
+  hashes = [
+    "h1:94qn780bi1qjrbC3uQtjJh3Wkfwd5+tTtJHOb7KTg9w=",
+    "zh:01702196f0a0492ec07917db7aaa595843d8f171dc195f4c988d2ffca2a06386",
+    "zh:09aae3da826ba3d7df69efeb25d146a1de0d03e951d35019a0f80e4f58c89b53",
+    "zh:09ba83c0625b6fe0a954da6fbd0c355ac0b7f07f86c91a2a97849140fea49603",
+    "zh:0e3a6c8e16f17f19010accd0844187d524580d9fdb0731f675ffcf4afba03d16",
+    "zh:45f2c594b6f2f34ea663704cc72048b212fe7d16fb4cfd959365fa997228a776",
+    "zh:77ea3e5a0446784d77114b5e851c970a3dde1e08fa6de38210b8385d7605d451",
+    "zh:8a154388f3708e3df5a69122a23bdfaf760a523788a5081976b3d5616f7d30ae",
+    "zh:992843002f2db5a11e626b3fc23dc0c87ad3729b3b3cff08e32ffb3df97edbde",
+    "zh:ad906f4cebd3ec5e43d5cd6dc8f4c5c9cc3b33d2243c89c5fc18f97f7277b51d",
+    "zh:c979425ddb256511137ecd093e23283234da0154b7fa8b21c2687182d9aea8b2",
   ]
 }


### PR DESCRIPTION
# Summary
Update the Athena queries to use a new `logs` workgroup
as the `primary` workgroup already exists by default in the account.
This will allow us to add more workgroups in the future to segment
workloads and query types.

Also updates the Staging lock file with the new version constraints
and modules.

# ⚠️  Note
This was applied locally to test.

# Related
* #260 
* #253 