### PR TITLE
fix: saved Athena query syntax

### DIFF
--- a/terragrunt/aws/alarms/sql/athena_waf_all_requests.sql
+++ b/terragrunt/aws/alarms/sql/athena_waf_all_requests.sql
@@ -1,7 +1,6 @@
 SELECT 
     date_format(from_unixtime(timestamp / 1000e0), '%Y-%m-%d %T') as time, 
-    httprequest.httpmethod, httprequest.uri, label.name, action, labels, httprequest
-FROM 
-    `${database_name}.${table_name}`,
-    UNNEST(labels) as t(label)
-ORDER BY label.name, uri;
+    httprequest.httpmethod, httprequest.uri, action, httprequest
+FROM "${database_name}"."${table_name}"
+WHERE httprequest.uri <> '/healthcheck'
+ORDER BY time DESC;

--- a/terragrunt/aws/alarms/sql/athena_waf_blocked_requests.sql
+++ b/terragrunt/aws/alarms/sql/athena_waf_blocked_requests.sql
@@ -3,7 +3,7 @@ WITH data AS (
         date_format(from_unixtime(timestamp / 1000e0), '%Y-%m-%d') as time, header.value as host, action,
         terminatingruleid,
         httprequest.clientip, httprequest.country, httprequest.httpmethod, httprequest.uri
-    FROM `${database_name}.${table_name}`
+    FROM "${database_name}"."${table_name}"
     CROSS JOIN UNNEST(httprequest.headers) AS t(header)
     WHERE lower(header.name) = 'host'
     AND action = 'BLOCK'


### PR DESCRIPTION
# Summary
Use double quotes for database and table name.  Also removes
`/healthcheck` from the all requests query.

# Related
* #253 