### PR TITLE
chore: upgrade DB to postgres 11.16

### DIFF
--- a/terragrunt/aws/api/rds.tf
+++ b/terragrunt/aws/api/rds.tf
@@ -12,6 +12,6 @@ module "rds" {
   vpc_id                  = module.vpc.vpc_id
   engine_version          = "11.16"
 
-  upgrade_immediately         = true  
+  upgrade_immediately         = true
   allow_major_version_upgrade = true
 }

--- a/terragrunt/aws/api/rds.tf
+++ b/terragrunt/aws/api/rds.tf
@@ -1,5 +1,5 @@
 module "rds" {
-  source                  = "github.com/cds-snc/terraform-modules?ref=v0.0.35//rds"
+  source                  = "github.com/cds-snc/terraform-modules?ref=v3.0.14//rds"
   backup_retention_period = 7
   billing_tag_value       = var.billing_code
   database_name           = "scan_files"
@@ -10,5 +10,8 @@ module "rds" {
   username                = var.rds_username
   password                = var.rds_password
   vpc_id                  = module.vpc.vpc_id
-  engine_version          = "11.13"
+  engine_version          = "11.16"
+
+  upgrade_immediately         = true  
+  allow_major_version_upgrade = true
 }


### PR DESCRIPTION
# Summary
Upgrade the DB to 11.16, which has an upgrade path to 14.3.  Also
upgrades the `rds` Terraform module so that DB engine upgrades
can be applied immediately rather than during the maintenance window.

# Note
A manual DB snapshot has been taken.