### PR TITLE
chore: upgrade RDS postgres to 14.3

### DIFF
--- a/terragrunt/aws/api/rds.tf
+++ b/terragrunt/aws/api/rds.tf
@@ -10,7 +10,7 @@ module "rds" {
   username                = var.rds_username
   password                = var.rds_password
   vpc_id                  = module.vpc.vpc_id
-  engine_version          = "11.16"
+  engine_version          = "14.3"
 
   upgrade_immediately         = true
   allow_major_version_upgrade = true


### PR DESCRIPTION
# Summary 
Upgrade to Postgres version 14.3 as this is the highest
upgrade target available to us from 11.16.

# Related
* #277