### PR TITLE
feat: add WAF ACL rule toggle

### DIFF
--- a/terragrunt/.checkov.yml
+++ b/terragrunt/.checkov.yml
@@ -7,6 +7,7 @@ skip-check:
   - CKV_AWS_136 # ECR: default encryption key is acceptable 
   - CKV_AWS_149 # SecretsManager: default encryption key is acceptable
   - CKV_AWS_158 # CloudWatch: default encryption key is acceptable
+  - CKV_AWS_192 # WAF: False-positive, AWSManagedRulesKnownBadInputsRuleSet is being applied
   - CKV_AWS_28  # Dynamodb point in time recovery is not required
   - CKV_AWS_119 # AWS Managed keys are acceptable
   - CKV_AWS_241 # Kinesis: AWS Managed keys are acceptable

--- a/terragrunt/aws/api/inputs.tf
+++ b/terragrunt/aws/api/inputs.tf
@@ -1,6 +1,13 @@
 variable "api_auth_token" {
-  type      = string
-  sensitive = true
+  description = "The API auth token that must be added as a header to all requests to the API."
+  type        = string
+  sensitive   = true
+}
+
+variable "enable_waf" {
+  description = "Turn the the WAF on the API on or off.  This is only meant to be used during testing."
+  type        = bool
+  default     = true
 }
 
 variable "rds_password" {

--- a/terragrunt/aws/api/waf.tf
+++ b/terragrunt/aws/api/waf.tf
@@ -19,7 +19,17 @@ resource "aws_wafv2_web_acl" "api_waf" {
     priority = 1
 
     action {
-      block {}
+      dynamic "block" {
+        for_each = var.enable_waf == true ? [""] : []
+        content {
+        }
+      }
+
+      dynamic "count" {
+        for_each = var.enable_waf == false ? [""] : []
+        content {
+        }
+      }
     }
 
     statement {
@@ -44,7 +54,17 @@ resource "aws_wafv2_web_acl" "api_waf" {
     priority = 5
 
     action {
-      block {}
+      dynamic "block" {
+        for_each = var.enable_waf == true ? [""] : []
+        content {
+        }
+      }
+
+      dynamic "count" {
+        for_each = var.enable_waf == false ? [""] : []
+        content {
+        }
+      }
     }
 
     statement {
@@ -80,7 +100,17 @@ resource "aws_wafv2_web_acl" "api_waf" {
     priority = 10
 
     override_action {
-      none {}
+      dynamic "none" {
+        for_each = var.enable_waf == true ? [""] : []
+        content {
+        }
+      }
+
+      dynamic "count" {
+        for_each = var.enable_waf == false ? [""] : []
+        content {
+        }
+      }
     }
 
     statement {
@@ -102,7 +132,17 @@ resource "aws_wafv2_web_acl" "api_waf" {
     priority = 20
 
     action {
-      block {}
+      dynamic "block" {
+        for_each = var.enable_waf == true ? [""] : []
+        content {
+        }
+      }
+
+      dynamic "count" {
+        for_each = var.enable_waf == false ? [""] : []
+        content {
+        }
+      }
     }
 
     statement {
@@ -124,7 +164,17 @@ resource "aws_wafv2_web_acl" "api_waf" {
     priority = 30
 
     override_action {
-      none {}
+      dynamic "none" {
+        for_each = var.enable_waf == true ? [""] : []
+        content {
+        }
+      }
+
+      dynamic "count" {
+        for_each = var.enable_waf == false ? [""] : []
+        content {
+        }
+      }
     }
 
     statement {
@@ -180,7 +230,17 @@ resource "aws_wafv2_web_acl" "api_waf" {
     priority = 40
 
     override_action {
-      none {}
+      dynamic "none" {
+        for_each = var.enable_waf == true ? [""] : []
+        content {
+        }
+      }
+
+      dynamic "count" {
+        for_each = var.enable_waf == false ? [""] : []
+        content {
+        }
+      }
     }
 
     statement {
@@ -236,7 +296,17 @@ resource "aws_wafv2_web_acl" "api_waf" {
     priority = 50
 
     override_action {
-      none {}
+      dynamic "none" {
+        for_each = var.enable_waf == true ? [""] : []
+        content {
+        }
+      }
+
+      dynamic "count" {
+        for_each = var.enable_waf == false ? [""] : []
+        content {
+        }
+      }
     }
 
     statement {
@@ -258,7 +328,17 @@ resource "aws_wafv2_web_acl" "api_waf" {
     priority = 60
 
     override_action {
-      none {}
+      dynamic "none" {
+        for_each = var.enable_waf == true ? [""] : []
+        content {
+        }
+      }
+
+      dynamic "count" {
+        for_each = var.enable_waf == false ? [""] : []
+        content {
+        }
+      }
     }
 
     statement {

--- a/terragrunt/env/production/api/terragrunt.hcl
+++ b/terragrunt/env/production/api/terragrunt.hcl
@@ -17,6 +17,7 @@ dependency "hosted_zone" {
 }
 
 inputs = {
+  enable_waf     = true
   rds_username   = "databaseuser"
   hosted_zone_id = dependency.hosted_zone.outputs.hosted_zone_id
   oidc_exists    = false

--- a/terragrunt/env/staging/api/terragrunt.hcl
+++ b/terragrunt/env/staging/api/terragrunt.hcl
@@ -17,6 +17,7 @@ dependency "hosted_zone" {
 }
 
 inputs = {
+  enable_waf     = true
   rds_username   = "databaseuser"
   hosted_zone_id = dependency.hosted_zone.outputs.hosted_zone_id
   oidc_exists    = true


### PR DESCRIPTION
# Summary
Update the WAF ACL rules to make it possible to turn them all on
or off with a single boolean variable.

This will be used for testing only and the `enable_waf` variable
should be kept `true` for day-to-day use of the service.

# Related
* #274 