### PR TITLE
feat: create API CloudWatch warning alarm

### DIFF
--- a/api/clamav_scanner/clamav.py
+++ b/api/clamav_scanner/clamav.py
@@ -331,7 +331,7 @@ def is_clamd_running():
                 s.send(b"PING")
                 data = s.recv(32)
             except (socket.timeout, socket.error) as e:
-                log.error("Failed to read from socket: %s\n" % e)
+                log.warning("Failed to read from socket: %s\n" % e)
                 return False
 
         log.info("Received %s in response to PING" % repr(data))

--- a/terragrunt/aws/alarms/inputs.tf
+++ b/terragrunt/aws/alarms/inputs.tf
@@ -28,6 +28,11 @@ variable "scan_files_api_error_threshold" {
   type        = string
 }
 
+variable "scan_files_api_warning_threshold" {
+  description = "CloudWatch alarm threshold for the Scan Files API lambda function WARNING logs"
+  type        = string
+}
+
 variable "scan_files_api_scan_verdict_suspicious_threshold" {
   description = "CloudWatch alarm threshold for the Scan Files API scan verdicts that are suspicious"
   type        = string

--- a/terragrunt/env/production/alarms/terragrunt.hcl
+++ b/terragrunt/env/production/alarms/terragrunt.hcl
@@ -36,6 +36,7 @@ inputs = {
 
   s3_scan_object_error_threshold                   = "1"
   scan_files_api_error_threshold                   = "1"
+  scan_files_api_warning_threshold                 = "5"
   scan_files_api_scan_verdict_suspicious_threshold = "1"
 }
 

--- a/terragrunt/env/staging/alarms/terragrunt.hcl
+++ b/terragrunt/env/staging/alarms/terragrunt.hcl
@@ -36,6 +36,7 @@ inputs = {
 
   s3_scan_object_error_threshold                   = "1"
   scan_files_api_error_threshold                   = "1"
+  scan_files_api_warning_threshold                 = "5"
   scan_files_api_scan_verdict_suspicious_threshold = "1"
 }
 


### PR DESCRIPTION
# Summary
Add a CloudWatch alarm for API warnings and update the `is_clamd_running` function to log a warning when it cannot connect to the socket.

The reason for this is because returning `False` from this function is an expected state, and we only want to catch cases where it is continually occurring within a short period.

# Related
* #299 
* cds-snc/platform-core-services#119