### PR TITLE
fix: update prBodyNotes to use newline

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,6 @@
     "github>cds-snc/renovate-config"
   ],
   "prBodyNotes": [
-    "### Review \n- [ ] Updates tested and work as expected<br>- [ ] If this update is AWS related, its version still matches the infrastructure version (e.g. Lambda runtime, database engine, etc.)"
+    "### Review \n- [ ] Updates tested and work as expected \n- [ ] If this update is AWS related, its version still matches the infrastructure version (e.g. Lambda runtime, database engine, etc.)"
   ]
 }


### PR DESCRIPTION
# Summary
The newline is properly handled by Renovate's handlebars template and creates the expected line break.

# Related
* cds-snc/platform-core-services#118