### PR TITLE
chore: remove `prBodyNotes`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,5 @@
 {
   "extends": [
     "github>cds-snc/renovate-config"
-  ],
-  "prBodyNotes": [
-    "### Review \n- [ ] Updates tested and work as expected \n- [ ] If this update is AWS related, its version still matches the infrastructure version (e.g. Lambda runtime, database engine, etc.)"
   ]
 }


### PR DESCRIPTION
# Summary
This is now included in the org default Renovate config.

# Related
* cds-snc/renovate-config#9
* cds-snc/platform-core-services#118