### PR TITLE
chore: update checkov skip comment

### DIFF
--- a/terragrunt/.checkov.yml
+++ b/terragrunt/.checkov.yml
@@ -11,4 +11,4 @@ skip-check:
   - CKV_AWS_28  # Dynamodb point in time recovery is not required
   - CKV_AWS_119 # AWS Managed keys are acceptable
   - CKV_AWS_241 # Kinesis: AWS Managed keys are acceptable
-  - CKV2_AWS_32 # CloudFront: temporarily disable CSP check
+  - CKV2_AWS_32 # CloudFront: false-positive, distribution has a response_headers_policy_id defined


### PR DESCRIPTION
# Summary
Update the checkov skip comment for `CKV2_AWS_32` as a false-positive since the API's CloudFront distribution already includes a secure header policy for both the default and ordered cache behaviour blocks.

# Related
* Closes #305 