### PR TITLE
feat: create API config environment variables

### DIFF
--- a/.github/workflows/tf_apply_production.yml
+++ b/.github/workflows/tf_apply_production.yml
@@ -12,6 +12,7 @@ env:
   TERRAFORM_VERSION: 1.0.3
   TERRAGRUNT_VERSION: 0.38.4
   TF_VAR_api_auth_token: ${{ secrets.PRODUCTION_API_AUTH_TOKEN }}
+  TF_VAR_api_secret_environment_variables: ${{ secrets.PRODUCTION_API_SECRET_ENVIRONMENT_VARIABLES }}
   TF_VAR_aws_org_id: ${{ secrets.AWS_ORG_ID }}
   TF_VAR_aws_org_id_old: ${{ secrets.AWS_ORG_ID_OLD }}
   TF_VAR_rds_password: ${{ secrets.PRODUCTION_RDS_PASSWORD }}

--- a/.github/workflows/tf_apply_production.yml
+++ b/.github/workflows/tf_apply_production.yml
@@ -12,7 +12,7 @@ env:
   TERRAFORM_VERSION: 1.0.3
   TERRAGRUNT_VERSION: 0.38.4
   TF_VAR_api_auth_token: ${{ secrets.PRODUCTION_API_AUTH_TOKEN }}
-  TF_VAR_api_secret_environment_variables: ${{ secrets.PRODUCTION_API_SECRET_ENVIRONMENT_VARIABLES }}
+  TF_VAR_api_secret_environment_variables: '${{ secrets.PRODUCTION_API_SECRET_ENVIRONMENT_VARIABLES }}'
   TF_VAR_aws_org_id: ${{ secrets.AWS_ORG_ID }}
   TF_VAR_aws_org_id_old: ${{ secrets.AWS_ORG_ID_OLD }}
   TF_VAR_rds_password: ${{ secrets.PRODUCTION_RDS_PASSWORD }}

--- a/.github/workflows/tf_apply_staging.yml
+++ b/.github/workflows/tf_apply_staging.yml
@@ -13,6 +13,7 @@ env:
   TERRAFORM_VERSION: 1.0.3
   TERRAGRUNT_VERSION: 0.38.4
   TF_VAR_api_auth_token: ${{ secrets.STAGING_API_AUTH_TOKEN }}
+  TF_VAR_api_secret_environment_variables: ${{ secrets.STAGING_API_SECRET_ENVIRONMENT_VARIABLES }}
   TF_VAR_aws_org_id: ${{ secrets.AWS_ORG_ID }}
   TF_VAR_aws_org_id_old: ${{ secrets.AWS_ORG_ID_OLD }}
   TF_VAR_rds_password: ${{ secrets.STAGING_RDS_PASSWORD }}

--- a/.github/workflows/tf_apply_staging.yml
+++ b/.github/workflows/tf_apply_staging.yml
@@ -13,7 +13,7 @@ env:
   TERRAFORM_VERSION: 1.0.3
   TERRAGRUNT_VERSION: 0.38.4
   TF_VAR_api_auth_token: ${{ secrets.STAGING_API_AUTH_TOKEN }}
-  TF_VAR_api_secret_environment_variables: ${{ secrets.STAGING_API_SECRET_ENVIRONMENT_VARIABLES }}
+  TF_VAR_api_secret_environment_variables: '${{ secrets.STAGING_API_SECRET_ENVIRONMENT_VARIABLES }}'
   TF_VAR_aws_org_id: ${{ secrets.AWS_ORG_ID }}
   TF_VAR_aws_org_id_old: ${{ secrets.AWS_ORG_ID_OLD }}
   TF_VAR_rds_password: ${{ secrets.STAGING_RDS_PASSWORD }}

--- a/.github/workflows/tf_plan_production.yml
+++ b/.github/workflows/tf_plan_production.yml
@@ -13,7 +13,7 @@ env:
   TERRAGRUNT_VERSION: 0.38.4
   CONFTEST_VERSION: 0.27.0
   TF_VAR_api_auth_token: ${{ secrets.PRODUCTION_API_AUTH_TOKEN }}
-  TF_VAR_api_secret_environment_variables: ${{ secrets.PRODUCTION_API_SECRET_ENVIRONMENT_VARIABLES }}
+  TF_VAR_api_secret_environment_variables: '${{ secrets.PRODUCTION_API_SECRET_ENVIRONMENT_VARIABLES }}'
   TF_VAR_aws_org_id: ${{ secrets.AWS_ORG_ID }}
   TF_VAR_aws_org_id_old: ${{ secrets.AWS_ORG_ID_OLD }}
   TF_VAR_rds_password: ${{ secrets.PRODUCTION_RDS_PASSWORD }}

--- a/.github/workflows/tf_plan_production.yml
+++ b/.github/workflows/tf_plan_production.yml
@@ -13,6 +13,7 @@ env:
   TERRAGRUNT_VERSION: 0.38.4
   CONFTEST_VERSION: 0.27.0
   TF_VAR_api_auth_token: ${{ secrets.PRODUCTION_API_AUTH_TOKEN }}
+  TF_VAR_api_secret_environment_variables: ${{ secrets.PRODUCTION_API_SECRET_ENVIRONMENT_VARIABLES }}
   TF_VAR_aws_org_id: ${{ secrets.AWS_ORG_ID }}
   TF_VAR_aws_org_id_old: ${{ secrets.AWS_ORG_ID_OLD }}
   TF_VAR_rds_password: ${{ secrets.PRODUCTION_RDS_PASSWORD }}

--- a/.github/workflows/tf_plan_staging.yml
+++ b/.github/workflows/tf_plan_staging.yml
@@ -14,7 +14,7 @@ env:
   TERRAGRUNT_VERSION: 0.38.4
   CONFTEST_VERSION: 0.27.0
   TF_VAR_api_auth_token: ${{ secrets.STAGING_API_AUTH_TOKEN }}
-  TF_VAR_api_secret_environment_variables: ${{ secrets.STAGING_API_SECRET_ENVIRONMENT_VARIABLES }}
+  TF_VAR_api_secret_environment_variables: '${{ secrets.STAGING_API_SECRET_ENVIRONMENT_VARIABLES }}'
   TF_VAR_aws_org_id: ${{ secrets.AWS_ORG_ID }}
   TF_VAR_aws_org_id_old: ${{ secrets.AWS_ORG_ID_OLD }}
   TF_VAR_rds_password: ${{ secrets.STAGING_RDS_PASSWORD }}

--- a/.github/workflows/tf_plan_staging.yml
+++ b/.github/workflows/tf_plan_staging.yml
@@ -14,6 +14,7 @@ env:
   TERRAGRUNT_VERSION: 0.38.4
   CONFTEST_VERSION: 0.27.0
   TF_VAR_api_auth_token: ${{ secrets.STAGING_API_AUTH_TOKEN }}
+  TF_VAR_api_secret_environment_variables: ${{ secrets.STAGING_API_SECRET_ENVIRONMENT_VARIABLES }}
   TF_VAR_aws_org_id: ${{ secrets.AWS_ORG_ID }}
   TF_VAR_aws_org_id_old: ${{ secrets.AWS_ORG_ID_OLD }}
   TF_VAR_rds_password: ${{ secrets.STAGING_RDS_PASSWORD }}

--- a/terragrunt/aws/api/iam.tf
+++ b/terragrunt/aws/api/iam.tf
@@ -102,7 +102,7 @@ data "aws_iam_policy_document" "api_policies" {
       "ssm:GetParameters",
     ]
     resources = [
-      "arn:aws:ssm:${var.region}:${var.account_id}:parameter/ENVIRONMENT_VARIABLES"
+      aws_ssm_parameter.api_secret_environment_variables.arn
     ]
   }
 

--- a/terragrunt/aws/api/inputs.tf
+++ b/terragrunt/aws/api/inputs.tf
@@ -4,6 +4,12 @@ variable "api_auth_token" {
   sensitive   = true
 }
 
+variable "api_secret_environment_variables" {
+  description = "The secret environment variables loaded by the API on cold start."
+  type        = string
+  sensitive   = true
+}
+
 variable "enable_waf" {
   description = "Turn the the WAF on the API on or off.  This is only meant to be used during testing."
   type        = bool

--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -14,10 +14,15 @@ module "api" {
   }
 
   environment_variables = {
-    SQLALCHEMY_DATABASE_URI   = module.rds.proxy_connection_string_value
-    FILE_QUEUE_BUCKET         = module.file-queue.s3_bucket_id
-    API_AUTH_TOKEN_SECRET_ARN = aws_secretsmanager_secret.api_auth_token.id
-    POWERTOOLS_SERVICE_NAME   = "${var.product_name}-api"
+    API_AUTH_TOKEN_SECRET_ARN    = aws_secretsmanager_secret.api_auth_token.id
+    AV_DEFINITION_S3_BUCKET      = "${var.product_name}-${var.env}-clamav-defs"
+    COMPLETED_SCANS_TABLE_NAME   = "completed-scans"
+    FILE_CHECKSUM_TABLE_NAME     = "file-checksums"
+    FILE_QUEUE_BUCKET            = module.file-queue.s3_bucket_id
+    OPENAPI_URL                  = "/openapi.json"
+    POWERTOOLS_SERVICE_NAME      = "${var.product_name}-api"
+    SCAN_QUEUE_STATEMACHINE_NAME = "assemblyline-file-scan-queue"
+    SQLALCHEMY_DATABASE_URI      = module.rds.proxy_connection_string_value
   }
 
   policies = [

--- a/terragrunt/aws/api/secrets.tf
+++ b/terragrunt/aws/api/secrets.tf
@@ -11,3 +11,14 @@ resource "aws_secretsmanager_secret_version" "api_auth_token" {
   secret_id     = aws_secretsmanager_secret.api_auth_token.id
   secret_string = var.api_auth_token
 }
+
+resource "aws_ssm_parameter" "api_secret_environment_variables" {
+  name  = "ENVIRONMENT_VARIABLES"
+  type  = "SecureString"
+  value = var.api_secret_environment_variables
+
+  tags = {
+    CostCentre = var.billing_code
+    Terraform  = true
+  }
+}


### PR DESCRIPTION
# Summary

Update Terraform to include the creation of the `ENVIRONMENT_VARIABLES`
ParameterStore used to configure the API.

Non-sensitive values have been moved into the API lambda function's
environment variables.

# Related
* #311 