### PR TITLE
chore: change logging level to `error`

### DIFF
--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -19,6 +19,7 @@ module "api" {
     COMPLETED_SCANS_TABLE_NAME   = "completed-scans"
     FILE_CHECKSUM_TABLE_NAME     = "file-checksums"
     FILE_QUEUE_BUCKET            = module.file-queue.s3_bucket_id
+    LOG_LEVEL                    = "ERROR"
     OPENAPI_URL                  = "/openapi.json"
     POWERTOOLS_SERVICE_NAME      = "${var.product_name}-api"
     SCAN_QUEUE_STATEMACHINE_NAME = "assemblyline-file-scan-queue"

--- a/terragrunt/aws/s3_scan_object/lambda.tf
+++ b/terragrunt/aws/s3_scan_object/lambda.tf
@@ -10,6 +10,7 @@ module "s3_scan_object" {
   reserved_concurrent_executions = 3
 
   environment_variables = {
+    LOGGING_LEVEL                 = "error"
     SCAN_FILES_URL                = "https://${var.domain}"
     SCAN_FILES_API_KEY_SECRET_ARN = var.scan_files_api_key_secret_arn
     SNS_SCAN_COMPLETE_TOPIC_ARN   = aws_sns_topic.scan_complete.arn


### PR DESCRIPTION
# Summary
Update the API and S3 object module logging level to `error` to reduce the number of CloudWatch logs being created.