### PR TITLE
test: single pool connection

### DIFF
--- a/api/database/db.py
+++ b/api/database/db.py
@@ -2,6 +2,7 @@ import os
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
 
 if os.environ.get("CI"):
     connection_string = os.environ.get("SQLALCHEMY_DATABASE_TEST_URI")
@@ -11,10 +12,8 @@ else:
 db_engine = create_engine(
     connection_string,
     connect_args={"connect_timeout": 10},
-    pool_size=1,
-    pool_pre_ping=True,  # Check that a connection is still active before attempting to use
-    pool_recycle=1500,  # Prune connections older than 25 minutes (RDS Proxy has a timeout of 30 minutes)
-    pool_use_lifo=True,  # Re-use last connection used (allows server-side timeouts to remove unused connections)
+    poolclass=StaticPool,
+    pool_recycle=1500,
 )
 db_session = sessionmaker(bind=db_engine)
 

--- a/api/database/db.py
+++ b/api/database/db.py
@@ -13,7 +13,7 @@ db_engine = create_engine(
     connection_string,
     connect_args={"connect_timeout": 10},
     poolclass=StaticPool,
-    pool_recycle=1500,
+    pool_recycle=300,
 )
 db_session = sessionmaker(bind=db_engine)
 


### PR DESCRIPTION
# Summary 
Update the SQLAlchemey database engine to only have a single pool connection. We are using RDS proxy, which handles connection pooling for us.

# Related
- #226 