### PR TITLE
chore: use a single NAT gateway

### DIFF
--- a/terragrunt/aws/api/vpc.tf
+++ b/terragrunt/aws/api/vpc.tf
@@ -7,6 +7,8 @@ module "vpc" {
   block_ssh         = true
   block_rdp         = true
 
+  single_nat_gateway = var.env != "production"
+
   allow_https_request_out          = true
   allow_https_request_out_response = true
   allow_https_request_in           = true


### PR DESCRIPTION
# Summary
Update the VPC to only have a single NAT gateway
in non-prod environments.

# Related
- #373 