### PR TITLE
fix: set security events to allow SBOM publish

### DIFF
--- a/.github/workflows/build_and_push_production.yml
+++ b/.github/workflows/build_and_push_production.yml
@@ -16,6 +16,7 @@ permissions:
   actions: write
   checks: write
   statuses: write
+  security-events: write
 
 jobs:
   changes:

--- a/.github/workflows/build_and_push_staging.yml
+++ b/.github/workflows/build_and_push_staging.yml
@@ -16,6 +16,7 @@ permissions:
   actions: write
   checks: write
   statuses: write
+  security-events: write
 
 jobs:
   changes:

--- a/.github/workflows/ci_build_containers.yml
+++ b/.github/workflows/ci_build_containers.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/module/s3-scan-object/Dockerfile
+++ b/module/s3-scan-object/Dockerfile
@@ -4,6 +4,7 @@ ARG BASE_IMAGE=node:14.20.1-alpine3.16@sha256:b953f75739f5ddce593f8b7cf8542bbe5e
 FROM ${BASE_IMAGE} as builder
 
 ARG APP_DIR="/app"
+
 WORKDIR ${APP_DIR}
 
 RUN apk add --no-cache \


### PR DESCRIPTION
# Summary
Update the workflow permissions to allow the Docker image SBOM to be published.
