### PR TITLE
fix: add IP allowlist to WAF ACL

### DIFF
--- a/.github/workflows/tf_plan_production.yml
+++ b/.github/workflows/tf_plan_production.yml
@@ -64,7 +64,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Terraform plan
-        uses: cds-snc/terraform-plan@8be66db9c815352044405fd33120b91918bf1f2e # tag=v2.3.1
+        uses: cds-snc/terraform-plan@2d993abb8bfaa2d48bcd7793cd5602f004686a3a # tag=v3.0.0
         with:
           comment-delete: true
           comment-title: "Production: ${{ matrix.module }}"

--- a/.github/workflows/tf_plan_staging.yml
+++ b/.github/workflows/tf_plan_staging.yml
@@ -56,7 +56,7 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Terraform plan
-        uses: cds-snc/terraform-plan@8be66db9c815352044405fd33120b91918bf1f2e # tag=v2.3.1
+        uses: cds-snc/terraform-plan@2d993abb8bfaa2d48bcd7793cd5602f004686a3a # tag=v3.0.0
         with:
           comment-delete: true
           comment-title: "Staging: ${{ matrix.module }}"

--- a/terragrunt/aws/api/waf.tf
+++ b/terragrunt/aws/api/waf.tf
@@ -15,8 +15,29 @@ resource "aws_wafv2_web_acl" "api_waf" {
   }
 
   rule {
-    name     = "NorthAmericaOnly"
+    name     = "IpAllowList"
     priority = 1
+
+    action {
+      allow {}
+    }
+
+    statement {
+      ip_set_reference_statement {
+        arn = aws_wafv2_ip_set.ip_allowlist.arn
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "IpAllowList"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "NorthAmericaOnly"
+    priority = 2
 
     action {
       dynamic "block" {
@@ -448,4 +469,18 @@ resource "aws_wafv2_web_acl_logging_configuration" "api_waf" {
   provider                = aws.us-east-1
   log_destination_configs = [aws_kinesis_firehose_delivery_stream.api_waf.arn]
   resource_arn            = aws_wafv2_web_acl.api_waf.arn
+}
+
+# Azure US East CIDR blocks that are being identified as being in Germany
+# These should be allowed.
+resource "aws_wafv2_ip_set" "ip_allowlist" {
+  name               = "ip_allowlist"
+  scope              = "REGIONAL"
+  ip_address_version = "IPV4"
+  addresses = [
+    "172.172.0.0/15",
+    "172.174.0.0/16",
+    "172.175.0.0/16",
+    "172.176.0.0/15"
+  ]
 }


### PR DESCRIPTION
# Summary
Update the WAF ACL to allow Azure US East CIDR ranges through.  These are currently being misidentified as originating in Germany and being blocked by the geolocation match rule.

# Related
- #392 