### PR TITLE
feat: add DAST vulnerability scan

### DIFF
--- a/.github/workflows/dast_vulnerability_scan.yml
+++ b/.github/workflows/dast_vulnerability_scan.yml
@@ -1,0 +1,36 @@
+name: "DAST vulnerability scan"
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows:
+      - "Build, Push and Deploy to Staging"
+      - "Deploy Lambda Docker images to production"
+      - "Terraform apply production"
+      - "Terraform apply staging"      
+    types:
+      - completed
+
+jobs:
+  dast-vulnerability-scan:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - url: 'https://scan-files.alpha.canada.ca/docs'
+          - url: 'https://scan-files.cdssandbox.xyz/docs'
+    
+    steps:
+      - name: Run Dastardly
+        continue-on-error: true
+        uses: PortSwigger/dastardly-github-action@main
+        with:
+          target-url: '${{ matrix.url }}'
+
+      - name: Publish report
+        if: always()
+        uses: mikepenz/action-junit-report@ab07dd7abefd456d92ecbeb22f81392fafe3d528 # tag=v3.5.2
+        with:
+          report_paths: '**/dastardly-report.xml'
+          require_tests: true


### PR DESCRIPTION
# Summary
Add a workflow that uses [PortSwigger's Dastardly](https://portswigger.net/burp/dastardly) to run a DAST vulnerability scan after new deployments to Staging and Prod.

# Related
- cds-snc/platform-core-services#147