### PR TITLE
fix: tighten CORS headers

### DIFF
--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -96,8 +96,8 @@ resource "aws_lambda_function_url" "scan_files_url" {
 
   cors {
     allow_credentials = true
-    allow_origins     = ["*"]
-    allow_methods     = ["*"]
+    allow_origins     = ["https://${var.domain}"]
+    allow_methods     = ["POST, GET, OPTIONS"]
     max_age           = 86400
   }
 }


### PR DESCRIPTION
# Summary
Update the CORS headers to only allow requests from self and the API endpoint HTTP methods.

# Related
- cds-snc/platform-core-services#147