### PR TITLE
fix: CORS allowed methods

### DIFF
--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -97,7 +97,7 @@ resource "aws_lambda_function_url" "scan_files_url" {
   cors {
     allow_credentials = true
     allow_origins     = ["https://${var.domain}"]
-    allow_methods     = ["POST, GET, OPTIONS"]
+    allow_methods     = ["GET", "POST", "OPTIONS"]
     max_age           = 86400
   }
 }


### PR DESCRIPTION
# Summary
Update the CORS allowed methods to be an array of items instead of a single string.

# Related
- #397 
- cds-snc/platform-core-services#147