### PR TITLE
fix: replace unsupported method

### DIFF
--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -97,7 +97,7 @@ resource "aws_lambda_function_url" "scan_files_url" {
   cors {
     allow_credentials = true
     allow_origins     = ["https://${var.domain}"]
-    allow_methods     = ["GET", "POST", "OPTIONS"]
+    allow_methods     = ["GET", "POST", "HEAD"]
     max_age           = 86400
   }
 }


### PR DESCRIPTION
# Summary
`OPTIONS` method is not supported by AWS.

# Related
- cds-snc/platform-core-services#147