### PR TITLE
fix: update CloudFront CORS to include headers

### DIFF
--- a/terragrunt/aws/api/cloudfront.tf
+++ b/terragrunt/aws/api/cloudfront.tf
@@ -88,7 +88,7 @@ resource "aws_cloudfront_response_headers_policy" "security_headers_policy_api" 
     access_control_allow_credentials = true
 
     access_control_allow_headers {
-      items = ["*"]
+      items = ["Authorization", "Content-Type"]
     }
 
     access_control_allow_methods {


### PR DESCRIPTION
# Summary
Access control headers are required when allow credentials is true.

⚠️ This was applied locally to test.

# Related
- #402 