### PR TITLE
fix: remove all CORS configuration

### DIFF
--- a/.github/workflows/dast_vulnerability_scan.yml
+++ b/.github/workflows/dast_vulnerability_scan.yml
@@ -5,9 +5,7 @@ on:
   workflow_run:
     workflows:
       - "Build, Push and Deploy to Staging"
-      - "Deploy Lambda Docker images to production"
-      - "Terraform apply production"
-      - "Terraform apply staging"      
+      - "Deploy Lambda Docker images to production"   
     types:
       - completed
 
@@ -23,7 +21,6 @@ jobs:
     
     steps:
       - name: Run Dastardly
-        continue-on-error: true
         uses: PortSwigger/dastardly-github-action@main
         with:
           target-url: '${{ matrix.url }}'

--- a/terragrunt/aws/api/cloudfront.tf
+++ b/terragrunt/aws/api/cloudfront.tf
@@ -83,23 +83,6 @@ resource "aws_cloudfront_distribution" "scan_files_api" {
 resource "aws_cloudfront_response_headers_policy" "security_headers_policy_api" {
   name = "scan-files-security-headers-api"
 
-  cors_config {
-    origin_override                  = true
-    access_control_allow_credentials = true
-
-    access_control_allow_headers {
-      items = ["Authorization", "Content-Type"]
-    }
-
-    access_control_allow_methods {
-      items = ["GET", "POST", "HEAD", "OPTIONS"]
-    }
-
-    access_control_allow_origins {
-      items = ["https://${var.domain}"]
-    }
-  }
-
   security_headers_config {
     frame_options {
       frame_option = "DENY"

--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -93,11 +93,4 @@ resource "aws_lambda_function_url" "scan_files_url" {
   # checkov:skip=CKV_AWS_258: Lambda function url auth is handled at the API level
   function_name      = module.api.function_name
   authorization_type = "NONE"
-
-  cors {
-    allow_credentials = true
-    allow_origins     = ["https://${var.domain}"]
-    allow_methods     = ["GET", "POST", "HEAD"]
-    max_age           = 86400
-  }
 }


### PR DESCRIPTION
# Summary
Remove all CORS headers from requests.  These are not required
by the API or the OpenAPI `/docs` endpoint.

Also updates Dastardly workflow to only run after API deployments.

# ⚠️  Note
Terraform changes were applied locally to test.

# Related
- #400 