### PR TITLE
fix: DNS firewall VPC association priority

### DIFF
--- a/terragrunt/aws/api/route53.tf
+++ b/terragrunt/aws/api/route53.tf
@@ -73,16 +73,16 @@ resource "aws_route53_resolver_query_log_config_association" "route53_vpc_dns" {
 resource "aws_route53_resolver_firewall_domain_list" "allowed" {
   name = "AllowedDomains"
   domains = [
-    "*.cyber.gc.ca",
-    "*.${var.region}.rds.amazonaws.com",
-    "*.s3.${var.region}.amazonaws.com",
-    "current.cvd.clamav.net",
-    "database.clamav.net",
-    "lambda.${var.region}.amazonaws.com",
-    "secretsmanager.${var.region}.amazonaws.com",
-    "sns.${var.region}.amazonaws.com",
-    "ssm.${var.region}.amazonaws.com",
-    "sts.amazonaws.com"
+    "*.cyber.gc.ca.",
+    "*.${var.region}.rds.amazonaws.com.",
+    "*.s3.${var.region}.amazonaws.com.",
+    "current.cvd.clamav.net.",
+    "database.clamav.net.",
+    "lambda.${var.region}.amazonaws.com.",
+    "secretsmanager.${var.region}.amazonaws.com.",
+    "sns.${var.region}.amazonaws.com.",
+    "ssm.${var.region}.amazonaws.com.",
+    "sts.amazonaws.com."
   ]
 
   tags = {
@@ -93,7 +93,7 @@ resource "aws_route53_resolver_firewall_domain_list" "allowed" {
 
 resource "aws_route53_resolver_firewall_domain_list" "blocked" {
   name    = "BlockedDomains"
-  domains = ["*"]
+  domains = ["*."]
 
   tags = {
     CostCentre = var.billing_code

--- a/terragrunt/aws/api/route53.tf
+++ b/terragrunt/aws/api/route53.tf
@@ -130,6 +130,6 @@ resource "aws_route53_resolver_firewall_rule" "blocked" {
 resource "aws_route53_resolver_firewall_rule_group_association" "api_rules" {
   name                   = "ApiRules"
   firewall_rule_group_id = aws_route53_resolver_firewall_rule_group.api_rules.id
-  priority               = 100
+  priority               = 101
   vpc_id                 = module.vpc.vpc_id
 }


### PR DESCRIPTION
# Summary
Update the priority so that it is between 100 and 9900.  Error received on last TF apply was:

```
Error: error creating Route 53 Resolver DNS Firewall rule group association:
ValidationException: [RSLVR-02017] The priority value you provided is reserved.
Provide a number between "100" and "9900"
```

# Related
- #425 