### PR TITLE
fix: use `.amazonaws.com.` domain in domain list

### DIFF
--- a/terragrunt/aws/api/route53.tf
+++ b/terragrunt/aws/api/route53.tf
@@ -73,16 +73,10 @@ resource "aws_route53_resolver_query_log_config_association" "route53_vpc_dns" {
 resource "aws_route53_resolver_firewall_domain_list" "allowed" {
   name = "AllowedDomains"
   domains = [
+    "*.amazonaws.com.",
     "*.cyber.gc.ca.",
-    "*.${var.region}.rds.amazonaws.com.",
-    "*.s3.${var.region}.amazonaws.com.",
     "current.cvd.clamav.net.",
-    "database.clamav.net.",
-    "lambda.${var.region}.amazonaws.com.",
-    "secretsmanager.${var.region}.amazonaws.com.",
-    "sns.${var.region}.amazonaws.com.",
-    "ssm.${var.region}.amazonaws.com.",
-    "sts.amazonaws.com."
+    "database.clamav.net."
   ]
 
   tags = {


### PR DESCRIPTION
# Summary
Update the domain list to use the top level `amazonaws.com` domain since many of the service domains are CNAMEs referencing other AWS controlled domains which are getting blocked with our current specific service domain list.

# ⚠️  Note
This was applied locally to test.

# Related
- #425 