### PR TITLE
feat: Send scan verdict output to Sentinel

### DIFF
--- a/.github/workflows/tf_apply_production.yml
+++ b/.github/workflows/tf_apply_production.yml
@@ -17,6 +17,8 @@ env:
   TF_VAR_aws_org_id_old: ${{ secrets.AWS_ORG_ID_OLD }}
   TF_VAR_rds_password: ${{ secrets.PRODUCTION_RDS_PASSWORD }}
   TF_VAR_slack_webhook_url: ${{ secrets.SCAN_FILES_PROD_OPS_WEBHOOK }}
+  TF_VAR_sentinel_customer_id: ${{ secrets.SENTINEL_CUSTOMER_ID }}
+  TF_VAR_sentinel_shared_key: ${{ secrets.SENTINEL_SHARED_KEY }}
   AWS_REGION: ca-central-1
 
 permissions:

--- a/.github/workflows/tf_apply_staging.yml
+++ b/.github/workflows/tf_apply_staging.yml
@@ -18,6 +18,8 @@ env:
   TF_VAR_aws_org_id_old: ${{ secrets.AWS_ORG_ID_OLD }}
   TF_VAR_rds_password: ${{ secrets.STAGING_RDS_PASSWORD }}
   TF_VAR_slack_webhook_url: ${{ secrets.SCAN_FILES_STAGING_OPS_WEBHOOK }}
+  TF_VAR_sentinel_customer_id: ${{ secrets.SENTINEL_CUSTOMER_ID }}
+  TF_VAR_sentinel_shared_key: ${{ secrets.SENTINEL_SHARED_KEY }}
   AWS_REGION: ca-central-1
 
 permissions:

--- a/.github/workflows/tf_plan_production.yml
+++ b/.github/workflows/tf_plan_production.yml
@@ -18,6 +18,8 @@ env:
   TF_VAR_aws_org_id_old: ${{ secrets.AWS_ORG_ID_OLD }}
   TF_VAR_rds_password: ${{ secrets.PRODUCTION_RDS_PASSWORD }}
   TF_VAR_slack_webhook_url: ${{ secrets.SCAN_FILES_PROD_OPS_WEBHOOK }}
+  TF_VAR_sentinel_customer_id: ${{ secrets.SENTINEL_CUSTOMER_ID }}
+  TF_VAR_sentinel_shared_key: ${{ secrets.SENTINEL_SHARED_KEY }}
 
 permissions:
   id-token: write

--- a/.github/workflows/tf_plan_staging.yml
+++ b/.github/workflows/tf_plan_staging.yml
@@ -19,6 +19,8 @@ env:
   TF_VAR_aws_org_id_old: ${{ secrets.AWS_ORG_ID_OLD }}
   TF_VAR_rds_password: ${{ secrets.STAGING_RDS_PASSWORD }}
   TF_VAR_slack_webhook_url: ${{ secrets.SCAN_FILES_STAGING_OPS_WEBHOOK }}
+  TF_VAR_sentinel_customer_id: ${{ secrets.SENTINEL_CUSTOMER_ID }}
+  TF_VAR_sentinel_shared_key: ${{ secrets.SENTINEL_SHARED_KEY }}
 
 permissions:
   id-token: write

--- a/terragrunt/aws/alarms/inputs.tf
+++ b/terragrunt/aws/alarms/inputs.tf
@@ -38,6 +38,19 @@ variable "scan_files_api_scan_verdict_suspicious_threshold" {
   type        = string
 }
 
+variable "sentinel_customer_id" {
+  type        = string
+  sensitive   = true
+  description = "Sentinel customer ID"
+}
+
+variable "sentinel_shared_key" {
+  type        = string
+  sensitive   = true
+  description = "Sentinel customer ID"
+}
+
+
 variable "slack_webhook_url" {
   description = "Slack webhook URL that will be used to send notifications"
   type        = string

--- a/terragrunt/aws/alarms/sentinel_logging.tf
+++ b/terragrunt/aws/alarms/sentinel_logging.tf
@@ -1,0 +1,19 @@
+module "sentinel_forwarder" {
+  source            = "github.com/cds-snc/terraform-modules?ref=v4.0.2//sentinel_forwarder"
+  function_name     = "sentinel-cloud-watch-forwarder"
+  billing_tag_value = var.billing_code
+
+  customer_id = var.sentinel_customer_id
+  shared_key  = var.sentinel_shared_key
+
+  cloudwatch_log_arns = [var.scan_files_api_log_group_name]
+}
+
+
+resource "aws_cloudwatch_log_subscription_filter" "scan_verdict_suspicious" {
+  name            = local.scan_verdict_suspicious
+  log_group_name  = var.scan_files_api_log_group_name
+  filter_pattern  = "?suspicious ?malicious ?unknown ?unable_to_scan"
+  destination_arn = module.forwarder.lambda_arn
+  distribution    = "Random"
+}

--- a/terragrunt/aws/alarms/sentinel_logging.tf
+++ b/terragrunt/aws/alarms/sentinel_logging.tf
@@ -14,6 +14,6 @@ resource "aws_cloudwatch_log_subscription_filter" "scan_verdict_suspicious" {
   name            = local.scan_verdict_suspicious
   log_group_name  = var.scan_files_api_log_group_name
   filter_pattern  = "?suspicious ?malicious ?unknown ?unable_to_scan"
-  destination_arn = module.forwarder.lambda_arn
+  destination_arn = module.sentinel_forwarder.lambda_arn
   distribution    = "Random"
 }

--- a/terragrunt/aws/alarms/sentinel_logging.tf
+++ b/terragrunt/aws/alarms/sentinel_logging.tf
@@ -10,7 +10,7 @@ module "sentinel_forwarder" {
   customer_id = var.sentinel_customer_id
   shared_key  = var.sentinel_shared_key
 
-  cloudwatch_log_arns = [locals.scan_verdict_suspicious_arn]
+  cloudwatch_log_arns = [local.scan_verdict_suspicious_arn]
 }
 
 

--- a/terragrunt/aws/alarms/sentinel_logging.tf
+++ b/terragrunt/aws/alarms/sentinel_logging.tf
@@ -1,3 +1,7 @@
+locals {
+  scan_verdict_suspicious_arn = "arn:aws:logs:${var.region}:${var.account_id}:log-group:${var.scan_files_api_log_group_name}"
+}
+
 module "sentinel_forwarder" {
   source            = "github.com/cds-snc/terraform-modules?ref=v4.0.2//sentinel_forwarder"
   function_name     = "sentinel-cloud-watch-forwarder"
@@ -6,7 +10,7 @@ module "sentinel_forwarder" {
   customer_id = var.sentinel_customer_id
   shared_key  = var.sentinel_shared_key
 
-  cloudwatch_log_arns = [var.scan_files_api_log_group_name]
+  cloudwatch_log_arns = [locals.scan_verdict_suspicious_arn]
 }
 
 


### PR DESCRIPTION
This PR adds a CloudWatch Log subscription to send suspicious scan verdicts to Sentinel.