### PR TITLE
fix: warn when non-clean scan verdicts

### DIFF
--- a/api/clamav_scanner/clamav.py
+++ b/api/clamav_scanner/clamav.py
@@ -136,7 +136,9 @@ def update_defs_from_freshclam(path, library_path=""):
 
 
 def md5_from_file(filename):
-    hash_md5 = hashlib.md5()  # nosec - [B303:blacklist] MD5 being used for file hashing
+    hash_md5 = hashlib.md5(
+        usedforsecurity=False
+    )  # nosec B303, B324 MD5 being used for file hashing
     with open(filename, "rb") as f:
         for chunk in iter(lambda: f.read(4096), b""):
             hash_md5.update(chunk)

--- a/api/clamav_scanner/scan.py
+++ b/api/clamav_scanner/scan.py
@@ -98,7 +98,11 @@ def launch_scan(
         scan.verdict = scan_result
         scan.checksum = checksum
         scan.meta_data = {AV_SIGNATURE_METADATA: scan_signature}
-        log.info("Scan of %s resulted in %s\n" % (file_path, scan_result))
+
+        if scan_result == ScanVerdicts.CLEAN.value:
+            log.info("Scan of %s resulted in %s\n" % (file_path, scan_result))
+        else:
+            log.warning("Scan of %s resulted in %s\n" % (file_path, scan_result))
     except Exception as err:
         log.error("Scan %s failed. Reason %s" % (str(scan.id), str(err)))
         scan.completed = datetime.datetime.utcnow()


### PR DESCRIPTION
# Summary 
Update the ClamAV scanner logging so that it warns when a non-clean verdict is returned.

# Related
- #430 