### PR TITLE
chore: switch to resolver DNS Terraform module

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -54,9 +54,9 @@
       "moby": true
     },
     "terraform": {
-      "version": "1.0.3",
+      "version": "1.3.5",
       "tflint": "latest",
-      "terragrunt": "0.38.4"
+      "terragrunt": "0.40.2"
     },
     "aws-cli": {
       "version": "2.7.12"

--- a/.github/workflows/tf_apply_production.yml
+++ b/.github/workflows/tf_apply_production.yml
@@ -9,8 +9,8 @@ on:
       - ".github/workflows/tf_apply_production.yml"
 
 env:
-  TERRAFORM_VERSION: 1.0.3
-  TERRAGRUNT_VERSION: 0.38.4
+  TERRAFORM_VERSION: 1.3.5
+  TERRAGRUNT_VERSION: 0.40.2
   TF_VAR_api_auth_token: ${{ secrets.PRODUCTION_API_AUTH_TOKEN }}
   TF_VAR_api_secret_environment_variables: '${{ secrets.PRODUCTION_API_SECRET_ENVIRONMENT_VARIABLES }}'
   TF_VAR_aws_org_id: ${{ secrets.AWS_ORG_ID }}

--- a/.github/workflows/tf_apply_staging.yml
+++ b/.github/workflows/tf_apply_staging.yml
@@ -10,8 +10,8 @@ on:
       - ".github/workflows/tf_apply_staging.yml"
 
 env:
-  TERRAFORM_VERSION: 1.0.3
-  TERRAGRUNT_VERSION: 0.38.4
+  TERRAFORM_VERSION: 1.3.5
+  TERRAGRUNT_VERSION: 0.40.2
   TF_VAR_api_auth_token: ${{ secrets.STAGING_API_AUTH_TOKEN }}
   TF_VAR_api_secret_environment_variables: '${{ secrets.STAGING_API_SECRET_ENVIRONMENT_VARIABLES }}'
   TF_VAR_aws_org_id: ${{ secrets.AWS_ORG_ID }}

--- a/.github/workflows/tf_plan_production.yml
+++ b/.github/workflows/tf_plan_production.yml
@@ -9,8 +9,8 @@ on:
 
 env:
   AWS_REGION: ca-central-1
-  TERRAFORM_VERSION: 1.0.3
-  TERRAGRUNT_VERSION: 0.38.4
+  TERRAFORM_VERSION: 1.3.5
+  TERRAGRUNT_VERSION: 0.40.2
   CONFTEST_VERSION: 0.27.0
   TF_VAR_api_auth_token: ${{ secrets.PRODUCTION_API_AUTH_TOKEN }}
   TF_VAR_api_secret_environment_variables: '${{ secrets.PRODUCTION_API_SECRET_ENVIRONMENT_VARIABLES }}'

--- a/.github/workflows/tf_plan_staging.yml
+++ b/.github/workflows/tf_plan_staging.yml
@@ -10,8 +10,8 @@ on:
 
 env:
   AWS_REGION: ca-central-1
-  TERRAFORM_VERSION: 1.0.3
-  TERRAGRUNT_VERSION: 0.38.4
+  TERRAFORM_VERSION: 1.3.5
+  TERRAGRUNT_VERSION: 0.40.2
   CONFTEST_VERSION: 0.27.0
   TF_VAR_api_auth_token: ${{ secrets.STAGING_API_AUTH_TOKEN }}
   TF_VAR_api_secret_environment_variables: '${{ secrets.STAGING_API_SECRET_ENVIRONMENT_VARIABLES }}'

--- a/terragrunt/aws/api/route53.tf
+++ b/terragrunt/aws/api/route53.tf
@@ -26,104 +26,19 @@ resource "aws_route53_health_check" "scan_files_A" {
 }
 
 #
-# Route53 DNS logging
+# Route53 DNS logging and query firewall
 #
-resource "aws_cloudwatch_log_group" "route53_vpc_dns" {
-  name              = "/aws/route53/${module.vpc.vpc_id}"
-  retention_in_days = 14
-}
+module "resolver_dns" {
+  source           = "github.com/cds-snc/terraform-modules?ref=v4.0.3//resolver_dns"
+  vpc_id           = module.vpc.vpc_id
+  firewall_enabled = true
 
-data "aws_iam_policy_document" "route53_resolver_logging_policy" {
-  statement {
-    actions = [
-      "logs:CreateLogStream",
-      "logs:PutLogEvents",
-    ]
-
-    principals {
-      identifiers = ["route53.amazonaws.com"]
-      type        = "Service"
-    }
-
-    resources = [
-      "${aws_cloudwatch_log_group.route53_vpc_dns.arn}/*"
-    ]
-  }
-}
-
-resource "aws_cloudwatch_log_resource_policy" "route53_vpc_dns" {
-  policy_document = data.aws_iam_policy_document.route53_resolver_logging_policy.json
-  policy_name     = "route53_resolver_logging_policy"
-}
-
-resource "aws_route53_resolver_query_log_config" "route53_vpc_dns" {
-  name            = "route53_vpc_dns"
-  destination_arn = aws_cloudwatch_log_group.route53_vpc_dns.arn
-}
-
-resource "aws_route53_resolver_query_log_config_association" "route53_vpc_dns" {
-  resolver_query_log_config_id = aws_route53_resolver_query_log_config.route53_vpc_dns.id
-  resource_id                  = module.vpc.vpc_id
-}
-
-#
-# Resolve DNS firewall to only allow DNS queries to the `allowed` domains
-# and block all other queries
-#
-resource "aws_route53_resolver_firewall_domain_list" "allowed" {
-  name = "AllowedDomains"
-  domains = [
+  allowed_domains = [
     "*.amazonaws.com.",
     "*.cyber.gc.ca.",
     "current.cvd.clamav.net.",
     "database.clamav.net."
   ]
 
-  tags = {
-    CostCentre = var.billing_code
-    Terraform  = true
-  }
-}
-
-resource "aws_route53_resolver_firewall_domain_list" "blocked" {
-  name    = "BlockedDomains"
-  domains = ["*."]
-
-  tags = {
-    CostCentre = var.billing_code
-    Terraform  = true
-  }
-}
-
-resource "aws_route53_resolver_firewall_rule_group" "api_rules" {
-  name = "ApiRules"
-
-  tags = {
-    CostCentre = var.billing_code
-    Terraform  = true
-  }
-}
-
-resource "aws_route53_resolver_firewall_rule" "allowed" {
-  name                    = "AllowedDomains"
-  action                  = "ALLOW"
-  firewall_domain_list_id = aws_route53_resolver_firewall_domain_list.allowed.id
-  firewall_rule_group_id  = aws_route53_resolver_firewall_rule_group.api_rules.id
-  priority                = 100
-}
-
-resource "aws_route53_resolver_firewall_rule" "blocked" {
-  name                    = "BlockedDomains"
-  action                  = "BLOCK"
-  block_response          = "NODATA"
-  firewall_domain_list_id = aws_route53_resolver_firewall_domain_list.blocked.id
-  firewall_rule_group_id  = aws_route53_resolver_firewall_rule_group.api_rules.id
-  priority                = 200
-}
-
-resource "aws_route53_resolver_firewall_rule_group_association" "api_rules" {
-  name                   = "ApiRules"
-  firewall_rule_group_id = aws_route53_resolver_firewall_rule_group.api_rules.id
-  priority               = 101
-  vpc_id                 = module.vpc.vpc_id
+  billing_tag_value = var.billing_code
 }


### PR DESCRIPTION
# Summary
Update the resolver DNS query logging and firewall to use the new Terraform module.

Also bumps to the latest versions of Terraform and Terragrunt.

# ⚠️  Note
State migration was performed locally.

# Related
- #425