### PR TITLE
test: renovate config to group Docker and GitHub

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,24 @@
 {
   "extends": [
     "github>cds-snc/renovate-config"
+  ],
+  "packageRules": [
+    {
+      "description": "Group all GitHub action dependencies",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "separateMajorMinor": false,
+      "groupName": "all github action dependencies",
+      "groupSlug": "all-github-action"
+    },
+    {
+      "description": "Group all Docker image updates that are not major",
+      "matchDatasources": [
+        "docker"
+      ],
+      "groupName": "all docker images",
+      "groupSlug": "all-docker-images"
+    }
   ]
 }


### PR DESCRIPTION
# Summary 
Update the renovate config to test grouping of Docker and GitHub Action dependency updates.

- GitHub actions will have all updates grouped in a single PR, included major updates.
- Docker images will have all updates group except for major updates.

# Related
- cds-snc/platform-core-services#182