### PR TITLE
fix: do not group major Docker upgrades

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,14 @@
       "matchDatasources": [
         "docker"
       ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch",
+        "pin",
+        "pinDigest",
+        "digest",
+        "bump"
+      ],
       "groupName": "all docker images",
       "groupSlug": "all-docker-images"
     }


### PR DESCRIPTION
# Summary
Update the Renovate Docker config to only group minor, patch, pin and digest updates.

This will keep major version upgrades separate in their own PRs.

# Related
- cds-snc/platform-core-services#182