### PR TITLE
fix: Renovate Docker separate multiple major

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,14 +17,7 @@
       "matchDatasources": [
         "docker"
       ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch",
-        "pin",
-        "pinDigest",
-        "digest",
-        "bump"
-      ],
+      "separateMultipleMajor": true,
       "groupName": "all docker images",
       "groupSlug": "all-docker-images"
     }


### PR DESCRIPTION
# Summary
Update the Renovate Docker group package rule to use the `separateMultipleMajor` config item, which is a more elegant way of achieving the desired behaviour:

1. Group all non-major Docker updates into a single PR.
2. Create a single PR for each major Docker update.

# Related
- cds-snc/platform-core-services#182