### PR TITLE
fix: add AWS cli back to image

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -40,6 +40,7 @@ ENV PYTHONPATH=/pymodules
 
 RUN apk upgrade --no-cache \
     && apk add --no-cache \
+    aws-cli \
     binutils \
     clamav \
     clamav-daemon \

--- a/terragrunt/aws/alarms/alarms.tf
+++ b/terragrunt/aws/alarms/alarms.tf
@@ -31,7 +31,7 @@ resource "aws_cloudwatch_metric_alarm" "route53_health_check_api" {
 
 resource "aws_cloudwatch_log_metric_filter" "scan_files_api_error" {
   name           = local.error_logged_api
-  pattern        = "ERROR"
+  pattern        = "?ERROR ?error"
   log_group_name = var.scan_files_api_log_group_name
 
   metric_transformation {
@@ -118,7 +118,7 @@ resource "aws_cloudwatch_metric_alarm" "scan_verdict_suspicious" {
 
 resource "aws_cloudwatch_log_metric_filter" "s3_scan_object_error" {
   name           = local.error_logged_s3_scan_object
-  pattern        = "ERROR"
+  pattern        = "?ERROR ?error"
   log_group_name = var.s3_scan_object_log_group_name
 
   metric_transformation {


### PR DESCRIPTION
# Summary
The AWS cli is needed to retrieve the API's secret env vars.

Also updates the API and S3 scan object CloudWatch alarm filters to capture the `error` string.

# Related
- #370 
- #454 