### PR TITLE
fix: add ClamAV CloudFlare download URL

### DIFF
--- a/terragrunt/aws/alarms/alarms.tf
+++ b/terragrunt/aws/alarms/alarms.tf
@@ -31,7 +31,7 @@ resource "aws_cloudwatch_metric_alarm" "route53_health_check_api" {
 
 resource "aws_cloudwatch_log_metric_filter" "scan_files_api_error" {
   name           = local.error_logged_api
-  pattern        = "?ERROR ?error"
+  pattern        = "?ERROR ?error ?failed"
   log_group_name = var.scan_files_api_log_group_name
 
   metric_transformation {
@@ -118,7 +118,7 @@ resource "aws_cloudwatch_metric_alarm" "scan_verdict_suspicious" {
 
 resource "aws_cloudwatch_log_metric_filter" "s3_scan_object_error" {
   name           = local.error_logged_s3_scan_object
-  pattern        = "?ERROR ?error"
+  pattern        = "?ERROR ?error ?failed"
   log_group_name = var.s3_scan_object_log_group_name
 
   metric_transformation {

--- a/terragrunt/aws/api/route53.tf
+++ b/terragrunt/aws/api/route53.tf
@@ -37,7 +37,8 @@ module "resolver_dns" {
     "*.amazonaws.com.",
     "*.cyber.gc.ca.",
     "current.cvd.clamav.net.",
-    "database.clamav.net."
+    "database.clamav.net.",
+    "database.clamav.net.cdn.cloudflare.net."
   ]
 
   billing_tag_value = var.billing_code


### PR DESCRIPTION
# Summary
Update the resolver DNS to include the ClamAV CloudFlare download URL that the `database.clamav.net` CNAME.

Also update the CloudWatch alarm filter to capture `failed` log messages.

# Related
- #462 