### PR TITLE
feat: compress freshclam vuln database

### DIFF
--- a/api/conf/freshclam.conf
+++ b/api/conf/freshclam.conf
@@ -2,6 +2,7 @@
 # General
 ###############
 
+CompressLocalDatabase yes
 DatabaseDirectory /tmp/clamav
 LogSyslog false
 LogTime yes


### PR DESCRIPTION
# Summary
Update the freshclam config to compress its local database. This should help us gain some space to fit within the Lambda `/tmp` 512MB size limit.

# Related
- #460 