### PR TITLE
chore: remove redundant Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,39 +1,5 @@
 {
   "extends": [
     "github>cds-snc/renovate-config"
-  ],
-  "packageRules": [
-    {
-      "description": "Group all non-major GitHub actions",
-      "matchManagers": [
-        "github-actions"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch",
-        "pin",
-        "pinDigest",
-        "digest",
-        "bump"
-      ],
-      "groupName": "all non-major github action dependencies",
-      "groupSlug": "all-non-major-github-action"
-    },
-    {
-      "description": "Group all non-major Docker images",
-      "matchDatasources": [
-        "docker"
-      ],
-      "matchUpdateTypes": [
-        "minor",
-        "patch",
-        "pin",
-        "pinDigest",
-        "digest",
-        "bump"
-      ],
-      "groupName": "all non-major docker images",
-      "groupSlug": "all-non-major-docker-images"
-    }
   ]
 }


### PR DESCRIPTION
# Summary
This grouping config has now been added to the org's default Renovate config.

# Related
- cds-snc/renovate-config#28
- cds-snc/renovate-config#29