### PR TITLE
fix: increase API function's ephemeral storage

### DIFF
--- a/api/clamav_scanner/clamav.py
+++ b/api/clamav_scanner/clamav.py
@@ -115,19 +115,6 @@ def update_defs_from_freshclam(path, library_path=""):
         )
     log.info("Starting freshclam with defs in %s." % path)
 
-    # Debug available space in directory
-    du_proc = subprocess.run(
-        [
-            "du",
-            "-h",
-            "%s" % AV_DEFINITION_PATH,
-        ],
-        stderr=subprocess.STDOUT,
-        stdout=subprocess.PIPE,
-        env=fc_env,
-    )
-    log.info("du output:: %s" % du_proc.stdout.decode("utf-8"))
-
     fc_proc = subprocess.run(
         [
             FRESHCLAM_PATH,

--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -1,5 +1,5 @@
 module "api" {
-  source                 = "github.com/cds-snc/terraform-modules?ref=v0.0.45//lambda"
+  source                 = "github.com/cds-snc/terraform-modules?ref=v5.0.0//lambda"
   name                   = "${var.product_name}-api"
   billing_tag_value      = var.billing_code
   ecr_arn                = aws_ecr_repository.api.arn
@@ -7,6 +7,7 @@ module "api" {
   image_uri              = "${aws_ecr_repository.api.repository_url}:latest"
   memory                 = 3008
   timeout                = 300
+  ephemeral_storage      = 768
 
   vpc = {
     security_group_ids = [module.rds.proxy_security_group_id, aws_security_group.api.id]


### PR DESCRIPTION
# Summary
This will fix errors being raised by `freshclam` when it attempts to update the virus definitions and a `.cdiff` patch file does not exist.

Also removes the size debugging code from the API function code.

# Related
- Closes #472 (second time's the charm)