### PR TITLE
chore: update to latest stable ClamAV

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -42,11 +42,11 @@ RUN apk upgrade --no-cache \
     && apk add --no-cache \
     aws-cli \
     binutils \
-    clamav \
-    clamav-daemon \
-    clamav-clamdscan \
-    freshclam \
     libstdc++
+
+# Upgrade to latest stable ClamAV
+RUN sed -i "s/3.16/3.17/g" /etc/apk/repositories \
+    && apk add --no-cache clamav
 
 COPY bin/entry.sh /
 RUN chmod 555 /usr/bin/aws-lambda-rie /entry.sh


### PR DESCRIPTION
# Summary
Update to ClamAV 0.105.2 in the main Alpine 3.17 repository.

```sh
apk list -i | grep clam
freshclam-0.105.2-r0 x86_64 {clamav} (GPL-2.0-only WITH OpenSSL-Exception) [installed]
clamav-daemon-0.105.2-r0 x86_64 {clamav} (GPL-2.0-only WITH OpenSSL-Exception) [installed]
clamav-libs-0.105.2-r0 x86_64 {clamav} (GPL-2.0-only WITH OpenSSL-Exception) [installed]
clamav-clamdscan-0.105.2-r0 x86_64 {clamav} (GPL-2.0-only WITH OpenSSL-Exception) [installed]
clamav-scanner-0.105.2-r0 x86_64 {clamav} (GPL-2.0-only WITH OpenSSL-Exception) [installed]
clamav-0.105.2-r0 x86_64 {clamav} (GPL-2.0-only WITH OpenSSL-Exception) [installed]
```