### PR TITLE
fix: update scan verdict alarm to unknown

### DIFF
--- a/terragrunt/aws/alarms/alarms.tf
+++ b/terragrunt/aws/alarms/alarms.tf
@@ -2,7 +2,7 @@ locals {
   error_logged_api            = "ErrorLoggedAPI"
   error_logged_s3_scan_object = "ErrorLoggedS3ScanObject"
   error_namespace             = "ScanFiles"
-  scan_verdict_suspicious     = "ScanVerdictSuspicious"
+  scan_verdict_unknown        = "ScanVerdictUnknown"
   warning_logged_api          = "WarningLoggedAPI"
 }
 
@@ -87,29 +87,29 @@ resource "aws_cloudwatch_metric_alarm" "scan_files_api_warning" {
   ok_actions    = [aws_sns_topic.cloudwatch_warning.arn]
 }
 
-resource "aws_cloudwatch_log_metric_filter" "scan_verdict_suspicious" {
-  name           = local.scan_verdict_suspicious
-  pattern        = "?suspicious ?malicious ?unknown ?unable_to_scan"
+resource "aws_cloudwatch_log_metric_filter" "scan_verdict_unknown" {
+  name           = local.scan_verdict_unknown
+  pattern        = "?unknown ?unable_to_scan"
   log_group_name = var.scan_files_api_log_group_name
 
   metric_transformation {
-    name      = local.scan_verdict_suspicious
+    name      = local.scan_verdict_unknown
     namespace = local.error_namespace
     value     = "1"
   }
 }
 
-resource "aws_cloudwatch_metric_alarm" "scan_verdict_suspicious" {
-  alarm_name          = local.scan_verdict_suspicious
-  alarm_description   = "Scan verdicts that are malicious, suspicious, or that could not complete"
+resource "aws_cloudwatch_metric_alarm" "scan_verdict_unknown" {
+  alarm_name          = local.scan_verdict_unknown
+  alarm_description   = "Scans that returned an unknown or unable to scan verdict"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  metric_name         = aws_cloudwatch_log_metric_filter.scan_verdict_suspicious.metric_transformation[0].name
-  namespace           = aws_cloudwatch_log_metric_filter.scan_verdict_suspicious.metric_transformation[0].namespace
+  metric_name         = aws_cloudwatch_log_metric_filter.scan_verdict_unknown.metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.scan_verdict_unknown.metric_transformation[0].namespace
 
   period             = "60"
   evaluation_periods = "1"
   statistic          = "Sum"
-  threshold          = var.scan_files_api_scan_verdict_suspicious_threshold
+  threshold          = var.scan_files_api_scan_verdict_unknown_threshold
   treat_missing_data = "notBreaching"
 
   alarm_actions = [aws_sns_topic.cloudwatch_warning.arn]

--- a/terragrunt/aws/alarms/alarms.tf
+++ b/terragrunt/aws/alarms/alarms.tf
@@ -2,6 +2,7 @@ locals {
   error_logged_api            = "ErrorLoggedAPI"
   error_logged_s3_scan_object = "ErrorLoggedS3ScanObject"
   error_namespace             = "ScanFiles"
+  scan_verdict_suspicious     = "ScanVerdictSuspicious"
   scan_verdict_unknown        = "ScanVerdictUnknown"
   warning_logged_api          = "WarningLoggedAPI"
 }

--- a/terragrunt/aws/alarms/inputs.tf
+++ b/terragrunt/aws/alarms/inputs.tf
@@ -33,8 +33,8 @@ variable "scan_files_api_warning_threshold" {
   type        = string
 }
 
-variable "scan_files_api_scan_verdict_suspicious_threshold" {
-  description = "CloudWatch alarm threshold for the Scan Files API scan verdicts that are suspicious"
+variable "scan_files_api_scan_verdict_unknown_threshold" {
+  description = "CloudWatch alarm threshold for the Scan Files API scan verdicts that are unknown"
   type        = string
 }
 

--- a/terragrunt/env/production/alarms/terragrunt.hcl
+++ b/terragrunt/env/production/alarms/terragrunt.hcl
@@ -34,10 +34,10 @@ inputs = {
   route53_health_check_api_id    = dependency.api.outputs.route53_health_check_api_id
   api_cloudfront_distribution_id = dependency.api.outputs.api_cloudfront_distribution_id
 
-  s3_scan_object_error_threshold                   = "1"
-  scan_files_api_error_threshold                   = "1"
-  scan_files_api_warning_threshold                 = "5"
-  scan_files_api_scan_verdict_suspicious_threshold = "1"
+  s3_scan_object_error_threshold                = "1"
+  scan_files_api_error_threshold                = "1"
+  scan_files_api_warning_threshold              = "5"
+  scan_files_api_scan_verdict_unknown_threshold = "1"
 }
 
 include {

--- a/terragrunt/env/staging/alarms/terragrunt.hcl
+++ b/terragrunt/env/staging/alarms/terragrunt.hcl
@@ -34,10 +34,10 @@ inputs = {
   route53_health_check_api_id    = dependency.api.outputs.route53_health_check_api_id
   api_cloudfront_distribution_id = dependency.api.outputs.api_cloudfront_distribution_id
 
-  s3_scan_object_error_threshold                   = "1"
-  scan_files_api_error_threshold                   = "1"
-  scan_files_api_warning_threshold                 = "5"
-  scan_files_api_scan_verdict_suspicious_threshold = "1"
+  s3_scan_object_error_threshold                = "1"
+  scan_files_api_error_threshold                = "1"
+  scan_files_api_warning_threshold              = "5"
+  scan_files_api_scan_verdict_unknown_threshold = "1"
 }
 
 include {


### PR DESCRIPTION
# Summary 
Update the ClamAV scan verdict alarm to only trigger for scan verdicts that are `unknown` or `unable_to_scan`.

The reason for this change is because malicious/suspicious verdicts are expected and should be handled by the service downstream that is using scan files.