### PR TITLE
fix: remove reserved concurrency from function

### DIFF
--- a/terragrunt/aws/s3_scan_object/lambda.tf
+++ b/terragrunt/aws/s3_scan_object/lambda.tf
@@ -7,8 +7,6 @@ module "s3_scan_object" {
   memory    = 512
   timeout   = 60
 
-  reserved_concurrent_executions = 3
-
   environment_variables = {
     LOGGING_LEVEL                 = "warn"
     SCAN_FILES_URL                = "https://${var.domain}"


### PR DESCRIPTION
# Summary
The S3 scan object's reserved concurrency was set too low and was causing function throttles.

# Related
- #547 