### PR TITLE
fix: increase s3_scan_object timeout to 5 mins

### DIFF
--- a/terragrunt/aws/s3_scan_object/lambda.tf
+++ b/terragrunt/aws/s3_scan_object/lambda.tf
@@ -5,7 +5,7 @@ module "s3_scan_object" {
   image_uri = "${aws_ecr_repository.s3_scan_object.repository_url}:latest"
   ecr_arn   = aws_ecr_repository.s3_scan_object.arn
   memory    = 512
-  timeout   = 60
+  timeout   = 300
 
   environment_variables = {
     LOGGING_LEVEL                 = "warn"


### PR DESCRIPTION
# Summary
Update the s3_scan_object Lambda functions timeout to fix issues that were happening when large files were being scanned.

# Related
- #550 