### PR TITLE
fix: invoke scan files API via its function url

### DIFF
--- a/terragrunt/aws/api/outputs.tf
+++ b/terragrunt/aws/api/outputs.tf
@@ -30,6 +30,11 @@ output "function_role_arn" {
   value = "arn:aws:iam::${var.account_id}:role/${module.api.function_name}"
 }
 
+output "function_url" {
+  value     = aws_lambda_function_url.scan_files_url.function_url
+  sensitive = true
+}
+
 output "invoke_arn" {
   value = module.api.invoke_arn
 }

--- a/terragrunt/aws/s3_scan_object/inputs.tf
+++ b/terragrunt/aws/s3_scan_object/inputs.tf
@@ -12,3 +12,9 @@ variable "scan_files_api_key_secret_arn" {
   description = "ARN of the Scan Files API key secret"
   type        = string
 }
+
+variable "scan_files_api_function_url" {
+  description = "URL of the Scan Files API function"
+  type        = string
+  sensitive   = true
+}

--- a/terragrunt/aws/s3_scan_object/lambda.tf
+++ b/terragrunt/aws/s3_scan_object/lambda.tf
@@ -1,3 +1,7 @@
+data "aws_lambda_function_url" "scan_files_api" {
+  function_name = "${var.product_name}-api"
+}
+
 module "s3_scan_object" {
   source = "github.com/cds-snc/terraform-modules?ref=v3.0.6//lambda"
 
@@ -9,7 +13,7 @@ module "s3_scan_object" {
 
   environment_variables = {
     LOGGING_LEVEL                 = "warn"
-    SCAN_FILES_URL                = "https://${var.domain}"
+    SCAN_FILES_URL                = sensitive(data.aws_lambda_function_url.scan_files_api.function_url)
     SCAN_FILES_API_KEY_SECRET_ARN = var.scan_files_api_key_secret_arn
     SNS_SCAN_COMPLETE_TOPIC_ARN   = aws_sns_topic.scan_complete.arn
   }

--- a/terragrunt/aws/s3_scan_object/lambda.tf
+++ b/terragrunt/aws/s3_scan_object/lambda.tf
@@ -1,7 +1,3 @@
-data "aws_lambda_function_url" "scan_files_api" {
-  function_name = "${var.product_name}-api"
-}
-
 module "s3_scan_object" {
   source = "github.com/cds-snc/terraform-modules?ref=v3.0.6//lambda"
 
@@ -13,7 +9,7 @@ module "s3_scan_object" {
 
   environment_variables = {
     LOGGING_LEVEL                 = "warn"
-    SCAN_FILES_URL                = sensitive(data.aws_lambda_function_url.scan_files_api.function_url)
+    SCAN_FILES_URL                = var.scan_files_api_function_url
     SCAN_FILES_API_KEY_SECRET_ARN = var.scan_files_api_key_secret_arn
     SNS_SCAN_COMPLETE_TOPIC_ARN   = aws_sns_topic.scan_complete.arn
   }

--- a/terragrunt/env/production/s3_scan_object/terragrunt.hcl
+++ b/terragrunt/env/production/s3_scan_object/terragrunt.hcl
@@ -14,6 +14,7 @@ dependency "api" {
   mock_outputs = {
     function_name                 = ""
     function_role_arn             = ""
+    function_url                  = "http://localhost"
     scan_files_api_key_secret_arn = ""
   }
 }
@@ -21,6 +22,7 @@ dependency "api" {
 inputs = {
   scan_files_api_function_role_arn  = dependency.api.outputs.function_role_arn
   scan_files_api_function_role_name = dependency.api.outputs.function_name
+  scan_files_api_function_url       = dependency.api.outputs.function_url
   scan_files_api_key_secret_arn     = dependency.api.outputs.scan_files_api_key_secret_arn
 }
 

--- a/terragrunt/env/staging/s3_scan_object/terragrunt.hcl
+++ b/terragrunt/env/staging/s3_scan_object/terragrunt.hcl
@@ -14,6 +14,7 @@ dependency "api" {
   mock_outputs = {
     function_name                 = ""
     function_role_arn             = ""
+    function_url                  = "http://localhost"
     scan_files_api_key_secret_arn = ""
   }
 }
@@ -21,6 +22,7 @@ dependency "api" {
 inputs = {
   scan_files_api_function_role_arn  = dependency.api.outputs.function_role_arn
   scan_files_api_function_role_name = dependency.api.outputs.function_name
+  scan_files_api_function_url       = dependency.api.outputs.function_url
   scan_files_api_key_secret_arn     = dependency.api.outputs.scan_files_api_key_secret_arn
 }
 


### PR DESCRIPTION
# Summary
Update the S3 scan object lambda function to invoke the scan file API using its function URL.

This will bypass CloudFront and avoid any timeouts related to slow response times from the API which will happen under heavy load.

# Related
- #553 