### PR TITLE
fix: healthcheck query

### DIFF
--- a/api/database/db.py
+++ b/api/database/db.py
@@ -3,6 +3,7 @@ import os
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
+from sqlalchemy.sql import text
 
 if os.environ.get("CI"):
     connection_string = os.environ.get("SQLALCHEMY_DATABASE_TEST_URI")
@@ -27,6 +28,6 @@ def get_db_session():
 
 
 def get_db_version(session):
-    query = "SELECT version_num FROM alembic_version"
+    query = text("SELECT version_num FROM alembic_version")
     full_name = session.execute(query).fetchone()[0]
     return full_name


### PR DESCRIPTION
# Summary
Update the healthcheck so that it works with SQLAlchemy 2.x.

Error message that we're getting:
```
Textual SQL expression 'SELECT version_num FROM a...' should be explicitly declared as text('SELECT version_num FROM a...')
--
```

# Related
- #573 