### PR TITLE
chore: sync TF RDS version with AWS

### DIFF
--- a/terragrunt/aws/api/rds.tf
+++ b/terragrunt/aws/api/rds.tf
@@ -10,7 +10,7 @@ module "rds" {
   username                = var.rds_username
   password                = var.rds_password
   vpc_id                  = module.vpc.vpc_id
-  engine_version          = "14.3"
+  engine_version          = "14.5"
 
   upgrade_immediately         = true
   allow_major_version_upgrade = true


### PR DESCRIPTION
# Summary
Update the RDS engine version to match the minor version bump that was applied automatically by AWS.
