### PR TITLE
fix: initialize S3 scan object config in handler

### DIFF
--- a/module/s3-scan-object/app.test.js
+++ b/module/s3-scan-object/app.test.js
@@ -11,9 +11,6 @@ const { STSClient, AssumeRoleCommand } = require("@aws-sdk/client-sts");
 const mockS3Client = mockClient(S3Client);
 const mockSecretManagerClient = mockClient(SecretsManagerClient);
 const mockSTSClient = mockClient(STSClient);
-mockSecretManagerClient.on(GetSecretValueCommand).resolves({
-  SecretString: "someSuperSecretValue",
-});
 
 const { handler, helpers } = require("./app.js");
 const {
@@ -44,6 +41,12 @@ beforeEach(() => {
 });
 
 describe("handler", () => {
+  beforeEach(() => {
+    mockSecretManagerClient.on(GetSecretValueCommand).resolves({
+      SecretString: "someSuperSecretValue",
+    });
+  });
+
   test("records success", async () => {
     const event = {
       AccountId: "123456789012",

--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -5,7 +5,7 @@ module "api" {
   ecr_arn                = aws_ecr_repository.api.arn
   enable_lambda_insights = true
   image_uri              = "${aws_ecr_repository.api.repository_url}:latest"
-  memory                 = 3008
+  memory                 = 5308
   timeout                = 300
   ephemeral_storage      = 768
 
@@ -20,7 +20,7 @@ module "api" {
     COMPLETED_SCANS_TABLE_NAME   = "completed-scans"
     FILE_CHECKSUM_TABLE_NAME     = "file-checksums"
     FILE_QUEUE_BUCKET            = module.file-queue.s3_bucket_id
-    LOG_LEVEL                    = "WARNING"
+    LOG_LEVEL                    = "INFO"
     OPENAPI_URL                  = "/openapi.json"
     POWERTOOLS_SERVICE_NAME      = "${var.product_name}-api"
     SCAN_QUEUE_STATEMACHINE_NAME = "assemblyline-file-scan-queue"

--- a/terragrunt/aws/s3_scan_object/lambda.tf
+++ b/terragrunt/aws/s3_scan_object/lambda.tf
@@ -4,11 +4,11 @@ module "s3_scan_object" {
   name      = "s3-scan-object"
   image_uri = "${aws_ecr_repository.s3_scan_object.repository_url}:latest"
   ecr_arn   = aws_ecr_repository.s3_scan_object.arn
-  memory    = 512
+  memory    = 1024
   timeout   = 300
 
   environment_variables = {
-    LOGGING_LEVEL                 = "warn"
+    LOGGING_LEVEL                 = "debug"
     SCAN_FILES_URL                = var.scan_files_api_function_url
     SCAN_FILES_API_KEY_SECRET_ARN = var.scan_files_api_key_secret_arn
     SNS_SCAN_COMPLETE_TOPIC_ARN   = aws_sns_topic.scan_complete.arn


### PR DESCRIPTION
# Summary
Update how the SecretManager API key is retrieved to only occur once during the first cold start's handler invocation.

Previously a Promise was created during function init and then resolved on the first handler call.  The problem this created is that occasionally we would get `InvalidSignatureExceptions` when the handler was executed more than 5 minutes after the initial promise creation.

This PR also increases the lambda function's resources and adds more debug logging.

# Related
- cds-snc/platform-core-services#297
- cds-snc/platform-core-services#355
- aws/aws-sdk-js-v3#4429