### PR TITLE
Revert "fix: Route53 healthcheck all regions"

### DIFF
--- a/terragrunt/aws/api/route53.tf
+++ b/terragrunt/aws/api/route53.tf
@@ -17,6 +17,7 @@ resource "aws_route53_health_check" "scan_files_A" {
   resource_path     = "/healthcheck"
   failure_threshold = "5"
   request_interval  = "30"
+  regions           = ["us-east-1", "us-west-1", "us-west-2"]
 
   tags = {
     CostCentre = var.billing_code


### PR DESCRIPTION
# Summary
Reverts cds-snc/scan-files#605.  Having the extra health check regions is not solving the concurrency problem.

# Related
- cds-snc/platform-core-services#297