### PR TITLE
revert: lambda function resource increase

### DIFF
--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -5,7 +5,7 @@ module "api" {
   ecr_arn                = aws_ecr_repository.api.arn
   enable_lambda_insights = true
   image_uri              = "${aws_ecr_repository.api.repository_url}:latest"
-  memory                 = 5308
+  memory                 = 3008
   timeout                = 300
   ephemeral_storage      = 768
 

--- a/terragrunt/aws/integration_test/s3_scan_object.tf
+++ b/terragrunt/aws/integration_test/s3_scan_object.tf
@@ -1,11 +1,13 @@
 module "integration_test" {
-  source = "github.com/cds-snc/terraform-modules?ref=v3.0.10//S3_scan_object"
+  source = "github.com/cds-snc/terraform-modules?ref=v5.1.11//S3_scan_object"
 
   product_name                = "integration-test"
   s3_upload_bucket_name       = module.integration_test_bucket.s3_bucket_id
   scan_files_role_arn         = "arn:aws:iam::${var.account_id}:role/scan-files-api"
   s3_scan_object_function_arn = "arn:aws:lambda:ca-central-1:${var.account_id}:function:s3-scan-object"
   s3_scan_object_role_arn     = "arn:aws:iam::${var.account_id}:role/s3-scan-object"
+
+  log_level = "DEBUG"
 
   billing_tag_value = var.billing_code
 }

--- a/terragrunt/aws/s3_scan_object/lambda.tf
+++ b/terragrunt/aws/s3_scan_object/lambda.tf
@@ -4,7 +4,7 @@ module "s3_scan_object" {
   name      = "s3-scan-object"
   image_uri = "${aws_ecr_repository.s3_scan_object.repository_url}:latest"
   ecr_arn   = aws_ecr_repository.s3_scan_object.arn
-  memory    = 1024
+  memory    = 512
   timeout   = 300
 
   environment_variables = {


### PR DESCRIPTION
# Summary
Revert the API and S3 scan object functions to their original memory resource values.  
The increased memory and vCPU is not having any impact over `clamd` init time.

![image](https://github.com/cds-snc/scan-files/assets/2110107/2718d003-badf-4c9b-8f98-55f40bede162)


# Related
- cds-snc/platform-core-services#297
- cds-snc/platform-core-services#358