### PR TITLE
fix: add more logging to `s3_scan_object` module

### DIFF
--- a/terragrunt/aws/integration_test/s3_scan_object.tf
+++ b/terragrunt/aws/integration_test/s3_scan_object.tf
@@ -1,13 +1,9 @@
 module "integration_test" {
-  source = "github.com/cds-snc/terraform-modules?ref=v5.1.11//S3_scan_object"
+  source = "github.com/cds-snc/terraform-modules?ref=v6.0.1//S3_scan_object"
 
-  product_name                = "integration-test"
-  s3_upload_bucket_name       = module.integration_test_bucket.s3_bucket_id
-  scan_files_role_arn         = "arn:aws:iam::${var.account_id}:role/scan-files-api"
-  s3_scan_object_function_arn = "arn:aws:lambda:ca-central-1:${var.account_id}:function:s3-scan-object"
-  s3_scan_object_role_arn     = "arn:aws:iam::${var.account_id}:role/s3-scan-object"
-
-  log_level = "DEBUG"
+  s3_upload_bucket_name   = module.integration_test_bucket.s3_bucket_id
+  scan_files_role_arn     = "arn:aws:iam::${var.account_id}:role/scan-files-api"
+  s3_scan_object_role_arn = "arn:aws:iam::${var.account_id}:role/s3-scan-object"
 
   billing_tag_value = var.billing_code
 }

--- a/terragrunt/aws/s3_scan_object/lambda.tf
+++ b/terragrunt/aws/s3_scan_object/lambda.tf
@@ -8,7 +8,7 @@ module "s3_scan_object" {
   timeout   = 300
 
   environment_variables = {
-    LOGGING_LEVEL                 = "debug"
+    LOGGING_LEVEL                 = "info"
     SCAN_FILES_URL                = var.scan_files_api_function_url
     SCAN_FILES_API_KEY_SECRET_ARN = var.scan_files_api_key_secret_arn
     SNS_SCAN_COMPLETE_TOPIC_ARN   = aws_sns_topic.scan_complete.arn


### PR DESCRIPTION
# Summary
Add more log statements to `s3_scan_object` and change from debug to info.  This will remove the third party dependency debug log statements from our logs.

Also update the integration test to use the new SQS queue version of the `s3_scan_object` Terraform module.

# Related
- cds-snc/platform-core-services#297