### PR TITLE
fix: log scan failure error more generally

### DIFF
--- a/module/s3-scan-object/app.js
+++ b/module/s3-scan-object/app.js
@@ -365,7 +365,7 @@ const startS3ObjectScan = async (apiEndpoint, apiKey, s3Object, awsAccountId, sn
     logger.info(`S3 scan response ${response.status}: ${util.inspect(response.data)}`);
     return response;
   } catch (error) {
-    logger.error(`Could not start scan for ${util.inspect(s3Object)}: ${util.inspect(error.response)}`);
+    logger.error(`Could not start scan for ${util.inspect(s3Object)}: ${util.inspect(error)}`);
     return error.response;
   }
 };


### PR DESCRIPTION
# Summary
Update the error handling for the `s3_scan_object` module so that failures to invoke the API are more clearly logged.