### PR TITLE
fix: update Notify Staging to use Staging

### DIFF
--- a/terragrunt/env/production/s3_scan_object/terragrunt.hcl
+++ b/terragrunt/env/production/s3_scan_object/terragrunt.hcl
@@ -24,7 +24,7 @@ inputs = {
   scan_files_api_function_role_name = dependency.api.outputs.function_name
   scan_files_api_function_url       = dependency.api.outputs.function_url
   scan_files_api_key_secret_arn     = dependency.api.outputs.scan_files_api_key_secret_arn
-  sqs_event_accounts                = ["239043911459", "296255494825", "687401027353", "806545929748", "957818836222"]
+  sqs_event_accounts                = ["296255494825", "687401027353", "806545929748", "957818836222"]
 }
 
 include {

--- a/terragrunt/env/staging/s3_scan_object/terragrunt.hcl
+++ b/terragrunt/env/staging/s3_scan_object/terragrunt.hcl
@@ -24,7 +24,7 @@ inputs = {
   scan_files_api_function_role_name = dependency.api.outputs.function_name
   scan_files_api_function_url       = dependency.api.outputs.function_url
   scan_files_api_key_secret_arn     = dependency.api.outputs.scan_files_api_key_secret_arn
-  sqs_event_accounts                = ["127893201980"]
+  sqs_event_accounts                = ["239043911459", "127893201980"]
 }
 
 include {


### PR DESCRIPTION
# Summary
Update the Notify Staging environment to use the Scan Files Staging environment.  

This will isolate Prod from Notify Staging pen and load testing.

# Related
- https://github.com/cds-snc/notification-terraform/pull/1053