### PR TITLE
fix: move API auth token into SSM ParameterStore

### DIFF
--- a/api/api_gateway/api.py
+++ b/api/api_gateway/api.py
@@ -3,7 +3,6 @@ from fastapi import FastAPI
 from os import environ
 from pydantic_settings import BaseSettings
 from starlette.middleware.base import BaseHTTPMiddleware
-from uuid import uuid4
 
 from .custom_middleware import add_security_headers, log_requests
 from .routers import ops, assemblyline, clamav
@@ -14,11 +13,13 @@ class Settings(BaseSettings):
 
 
 settings = Settings()
-API_AUTH_TOKEN = environ.get("API_AUTH_TOKEN", uuid4())
+API_AUTH_TOKEN = environ.get("API_AUTH_TOKEN")
 MLWR_HOST = environ.get("MLWR_HOST")
 MLWR_USER = environ.get("MLWR_USER")
 MLWR_KEY = environ.get("MLWR_KEY")
 
+if not API_AUTH_TOKEN:
+    raise Exception("API_AUTH_TOKEN environment variable is not set")
 
 description = """
 Scan files 📁 API. Submit files for malware scanning

--- a/api/api_gateway/custom_middleware.py
+++ b/api/api_gateway/custom_middleware.py
@@ -5,8 +5,6 @@ import time
 
 
 API_AUTH_TOKEN = environ.get("API_AUTH_TOKEN")
-if not API_AUTH_TOKEN:
-    raise Exception("API_AUTH_TOKEN environment variable is not set")
 
 
 async def add_security_headers(request: Request, call_next):

--- a/api/bin/entry.sh
+++ b/api/bin/entry.sh
@@ -15,7 +15,7 @@ var_expand() {
 load_non_existing_envs() {
   _isComment='^[[:space:]]*#'
   _isBlank='^[[:space:]]*$'
-  while IFS= read -r line; do
+  while IFS= read -r line || [ -n "$line" ]; do
     if echo "$line" | grep -Eq "$_isComment"; then # Ignore comment line
       continue
     fi
@@ -47,15 +47,11 @@ else
 
       # Retrieve secrets and write them to the .env file
       ENV_VARS="$(aws ssm get-parameters --region ca-central-1 --with-decryption --names ENVIRONMENT_VARIABLES --query 'Parameters[*].Value' --output text)"
-      API_AUTH_TOKEN="$(aws secretsmanager get-secret-value --region ca-central-1 --secret-id $API_AUTH_TOKEN_SECRET_ARN --query 'SecretString' --output text)"
-      if [ -z "$ENV_VARS" ] || [ -z "$API_AUTH_TOKEN" ]; then
+      if [ -z "$ENV_VARS" ]; then
         echo "ERROR Failed to retrieve secrets during init"
-        echo "ENV_VARS value: $ENV_VARS"
-        echo "API_AUTH_TOKEN value: $API_AUTH_TOKEN"
         exit 1
       else
         echo "$ENV_VARS" > "$TMP_ENV_FILE"
-        echo "API_AUTH_TOKEN=$API_AUTH_TOKEN" >> "$TMP_ENV_FILE"
       fi
     fi
 

--- a/api/tests/api_gateway/test_api.py
+++ b/api/tests/api_gateway/test_api.py
@@ -41,7 +41,7 @@ def test_healthcheck_failure(mock_log, mock_get_db_version):
     assert response.json() == expected_val
 
 
-@patch.dict(os.environ, {"OPENAPI_URL": ""}, clear=True)
+@patch.dict(os.environ, {"OPENAPI_URL": "", "API_AUTH_TOKEN": "secret"}, clear=True)
 def test_api_docs_disabled_via_environ():
     reload(api)
 
@@ -55,7 +55,9 @@ def test_api_docs_disabled_via_environ():
     assert response.status_code == 404
 
 
-@patch.dict(os.environ, {"OPENAPI_URL": "/openapi.json"}, clear=True)
+@patch.dict(
+    os.environ, {"OPENAPI_URL": "/openapi.json", "API_AUTH_TOKEN": "secret"}, clear=True
+)
 def test_api_docs_enabled_via_environ():
     reload(api)
 

--- a/terragrunt/aws/api/secrets.tf
+++ b/terragrunt/aws/api/secrets.tf
@@ -16,7 +16,6 @@ resource "aws_ssm_parameter" "api_secret_environment_variables" {
   name  = "ENVIRONMENT_VARIABLES"
   type  = "SecureString"
   value = var.api_secret_environment_variables
-
   tags = {
     CostCentre = var.billing_code
     Terraform  = true


### PR DESCRIPTION
# Summary
Update the SSM ParameterStore `ENVIRONMENT_VARIABLES` to include the API auth token.  In testing it was discovered that the SecretManager retrieval is behaving asynchronously so a small percentage of Lambda initializations are missing the correct value.

Also updates the check for an `API_AUTH_TOKEN` to the first section of the API where it is initialized.