### PR TITLE
chore: remove Forms scan files events

### DIFF
--- a/terragrunt/env/production/s3_scan_object/terragrunt.hcl
+++ b/terragrunt/env/production/s3_scan_object/terragrunt.hcl
@@ -24,7 +24,7 @@ inputs = {
   scan_files_api_function_role_name = dependency.api.outputs.function_name
   scan_files_api_function_url       = dependency.api.outputs.function_url
   scan_files_api_key_secret_arn     = dependency.api.outputs.scan_files_api_key_secret_arn
-  sqs_event_accounts                = ["296255494825", "687401027353", "806545929748", "957818836222"]
+  sqs_event_accounts                = ["296255494825", "806545929748"]
 }
 
 include {


### PR DESCRIPTION
# Summary
Remove the event listeners for the Forms scan files SQS queues.

# ⚠️  Note
This will have no TF plan changes as it only applies to production.