### PR TITLE
chore: bump s3_scan_object to node:20.11.0

### DIFF
--- a/module/s3-scan-object/Dockerfile
+++ b/module/s3-scan-object/Dockerfile
@@ -11,8 +11,8 @@ RUN apk add --no-cache \
     autoconf \
     automake \
     build-base \
+    elfutils-dev \
     libcurl \
-    libexecinfo-dev \
     libstdc++ \
     libtool \
     make \

--- a/module/s3-scan-object/Dockerfile
+++ b/module/s3-scan-object/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=node:20.11.0-alpine3.18@sha256:3aae0ea51b2952660b4b65988963b78b269cf84cc7f36f208462601a12e1531a
+ARG BASE_IMAGE=node:20.11.0-alpine3.19@sha256:2f46fd49c767554c089a5eb219115313b72748d8f62f5eccb58ef52bc36db4ad
 
 # Builder to install lambda dependencies
 FROM ${BASE_IMAGE} as builder
@@ -11,13 +11,16 @@ RUN apk add --no-cache \
     autoconf \
     automake \
     build-base \
-    elfutils-dev \
     libcurl \
     libstdc++ \
     libtool \
     make \
     cmake \
     python3
+
+# Install libexecinfo-dev from the Alpine v3.16 repository
+RUN apk add --no-cache --update --repository=https://dl-cdn.alpinelinux.org/alpine/v3.16/main/ \
+    libexecinfo-dev
 
 RUN npm install --prefix ${APP_DIR}/tmp aws-lambda-ric
 

--- a/module/s3-scan-object/Dockerfile
+++ b/module/s3-scan-object/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE=node:20.2.0-alpine3.16@sha256:f9b54b46639a9017b39eba677cf44c8cb96760ca69dadcc1d4cbd1daea753225
+ARG BASE_IMAGE=node:20.11.0-alpine3.18@sha256:3aae0ea51b2952660b4b65988963b78b269cf84cc7f36f208462601a12e1531a
 
 # Builder to install lambda dependencies
 FROM ${BASE_IMAGE} as builder

--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -17,6 +17,8 @@ module "api" {
   environment_variables = {
     API_AUTH_TOKEN_SECRET_ARN    = aws_secretsmanager_secret.api_auth_token.id
     AV_DEFINITION_S3_BUCKET      = "${var.product_name}-${var.env}-clamav-defs"
+    AWS_MAX_ATTEMPTS             = "5"
+    AWS_RETRY_MODE               = "standard"
     COMPLETED_SCANS_TABLE_NAME   = "completed-scans"
     FILE_CHECKSUM_TABLE_NAME     = "file-checksums"
     FILE_QUEUE_BUCKET            = module.file-queue.s3_bucket_id

--- a/terragrunt/aws/s3_scan_object/lambda.tf
+++ b/terragrunt/aws/s3_scan_object/lambda.tf
@@ -8,6 +8,8 @@ module "s3_scan_object" {
   timeout   = 300
 
   environment_variables = {
+    AWS_MAX_ATTEMPTS              = "5"
+    AWS_RETRY_MODE                = "standard"
     LOGGING_LEVEL                 = "info"
     SCAN_FILES_URL                = var.scan_files_api_function_url
     SCAN_FILES_API_KEY_SECRET_ARN = var.scan_files_api_key_secret_arn


### PR DESCRIPTION
# Summary
Upgrade the Node base image being used as this contains fixes that may help with the `ERR_SOCKET_CONNECTION_TIMEOUT` errors seen recently.

Increase the number of retries the AWS SDKs will perform when they receive a failure
response from an AWS service:
https://docs.aws.amazon.com/sdkref/latest/guide/feature-retry-behavior.html

# Related
- https://github.com/cds-snc/scan-files/issues/690