### PR TITLE
test: trigger a TF plan

### DIFF
--- a/.github/workflows/tf_plan_staging.yml
+++ b/.github/workflows/tf_plan_staging.yml
@@ -1,4 +1,4 @@
-name: "Terraform plan staging"
+name: "Terraform plan Staging"
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
# Summary 
Testing that RDS cert upgrade down out-of-bounds
does not get reverted by TF.

# Related
- https://github.com/cds-snc/platform-core-services/issues/544