### PR TITLE
feat: enable file scanning for both Staging and Production environments on GC Forms

### DIFF
--- a/terragrunt/env/production/s3_scan_object/terragrunt.hcl
+++ b/terragrunt/env/production/s3_scan_object/terragrunt.hcl
@@ -24,7 +24,7 @@ inputs = {
   scan_files_api_function_role_name = dependency.api.outputs.function_name
   scan_files_api_function_url       = dependency.api.outputs.function_url
   scan_files_api_key_secret_arn     = dependency.api.outputs.scan_files_api_key_secret_arn
-  sqs_event_accounts                = ["296255494825", "806545929748"]
+  sqs_event_accounts                = ["296255494825", "806545929748", "957818836222"]
 }
 
 include {

--- a/terragrunt/env/staging/s3_scan_object/terragrunt.hcl
+++ b/terragrunt/env/staging/s3_scan_object/terragrunt.hcl
@@ -24,7 +24,7 @@ inputs = {
   scan_files_api_function_role_name = dependency.api.outputs.function_name
   scan_files_api_function_url       = dependency.api.outputs.function_url
   scan_files_api_key_secret_arn     = dependency.api.outputs.scan_files_api_key_secret_arn
-  sqs_event_accounts                = ["239043911459", "127893201980"]
+  sqs_event_accounts                = ["239043911459", "127893201980", "687401027353"]
 }
 
 include {


### PR DESCRIPTION
# Summary | Résumé

linked to https://github.com/cds-snc/forms-terraform/pull/611

- Enable file scanning for both Staging and Production environments on GC Forms