### PR TITLE
feat: setup provisioned concurrency

### DIFF
--- a/terragrunt/aws/api/cloudfront.tf
+++ b/terragrunt/aws/api/cloudfront.tf
@@ -5,8 +5,8 @@ resource "aws_cloudfront_distribution" "scan_files_api" {
   web_acl_id  = aws_wafv2_web_acl.api_waf.arn
 
   origin {
-    domain_name = split("/", aws_lambda_function_url.scan_files_url.function_url)[2]
-    origin_id   = aws_lambda_function_url.scan_files_url.function_name
+    domain_name = split("/", aws_lambda_function_url.scan_files["api"].function_url)[2]
+    origin_id   = aws_lambda_function_url.scan_files["api"].function_name
 
     custom_origin_config {
       http_port              = 80
@@ -28,7 +28,7 @@ resource "aws_cloudfront_distribution" "scan_files_api" {
       }
     }
 
-    target_origin_id           = aws_lambda_function_url.scan_files_url.function_name
+    target_origin_id           = aws_lambda_function_url.scan_files["api"].function_name
     viewer_protocol_policy     = "redirect-to-https"
     response_headers_policy_id = aws_cloudfront_response_headers_policy.security_headers_policy_api.id
   }
@@ -46,7 +46,7 @@ resource "aws_cloudfront_distribution" "scan_files_api" {
       }
     }
 
-    target_origin_id           = aws_lambda_function_url.scan_files_url.function_name
+    target_origin_id           = aws_lambda_function_url.scan_files["api"].function_name
     viewer_protocol_policy     = "redirect-to-https"
     response_headers_policy_id = aws_cloudfront_response_headers_policy.security_headers_policy_api.id
 

--- a/terragrunt/aws/api/iam.tf
+++ b/terragrunt/aws/api/iam.tf
@@ -112,7 +112,8 @@ data "aws_iam_policy_document" "api_policies" {
       "lambda:InvokeFunction"
     ]
     resources = [
-      module.api.function_arn
+      module.scan_files["api"].function_arn,
+      module.scan_files["api-provisioned"].function_arn
     ]
   }
 }

--- a/terragrunt/aws/api/moved.tf
+++ b/terragrunt/aws/api/moved.tf
@@ -1,0 +1,19 @@
+moved {
+  from = module.api
+  to   = module.scan_files["api"]
+}
+
+moved {
+  from = module.api_provisioned
+  to   = module.scan_files["api-provisioned"]
+}
+
+moved {
+  from = aws_lambda_function_url.scan_files_url
+  to   = aws_lambda_function_url.scan_files["api"]
+}
+
+moved {
+  from = aws_lambda_function_url.scan_files_provisioned_url
+  to   = aws_lambda_function_url.scan_files["api-provisioned"]
+}

--- a/terragrunt/aws/api/outputs.tf
+++ b/terragrunt/aws/api/outputs.tf
@@ -15,28 +15,28 @@ output "log_bucket_id" {
 }
 
 output "function_arn" {
-  value = module.api.function_arn
+  value = module.scan_files["api"].function_arn
 }
 
 output "function_log_group_name" {
-  value = "/aws/lambda/${module.api.function_name}"
+  value = "/aws/lambda/${module.scan_files["api"].function_name}"
 }
 
 output "function_name" {
-  value = module.api.function_name
+  value = module.scan_files["api"].function_name
 }
 
 output "function_role_arn" {
-  value = "arn:aws:iam::${var.account_id}:role/${module.api.function_name}"
+  value = "arn:aws:iam::${var.account_id}:role/${module.scan_files["api"].function_name}"
 }
 
 output "function_url" {
-  value     = aws_lambda_function_url.scan_files_url.function_url
+  value     = aws_lambda_function_url.scan_files["api"].function_url
   sensitive = true
 }
 
 output "invoke_arn" {
-  value = module.api.invoke_arn
+  value = module.scan_files["api"].invoke_arn
 }
 
 output "route53_health_check_api_id" {

--- a/terragrunt/env/staging/api/.terraform.lock.hcl
+++ b/terragrunt/env/staging/api/.terraform.lock.hcl
@@ -65,32 +65,3 @@ provider "registry.terraform.io/hashicorp/random" {
     "zh:f1ca75f417ce490368f047b63ec09fd003711ae48487fba90b4aba2ccf71920e",
   ]
 }
-
-provider "registry.terraform.io/hashicorp/tls" {
-  version = "4.0.5"
-  hashes = [
-    "h1:SpREFWxsO6caOBVOuZx7ee4eAh5WnNjY6HRqQL7R3hc=",
-    "h1:cvWAu883DXYa5z6cp4stvI8ooR2ricohGq2H194ehP8=",
-    "h1:e4LBdJoZJNOQXPWgOAG0UuPBVhCStu98PieNlqJTmeU=",
-    "h1:gthwVUwv0WLGMwx7GR/N6XyIONzrSJJaXD6dDJB4FlY=",
-    "h1:jb/Rg9inGYp4t8HtBoETESsQJgdmOHoe1bzzg2uNB3w=",
-    "h1:kcw9sNLNFMY2S0HIGOkjlwKtUc8lpqZsQGsC2SG9xEQ=",
-    "h1:wxJZSMdVsNYqwmts0PAbm0VRLP66jkcgEwHhoCRP5KU=",
-    "h1:y3MWoyIFikBuGEKRvCi/HYJ9j1NVu8sMHKXjtaOSR8A=",
-    "h1:yLqz+skP3+EbU3yyvw8JqzflQTKDQGsC9QyZAg+S4dg=",
-    "h1:ySnfE8OMhcxx7KjmWoYr2WC33iMflR2lWDRuMTU5TXA=",
-    "h1:zeG5RmggBZW/8JWIVrdaeSJa0OG62uFX5HY1eE8SjzY=",
-    "zh:01cfb11cb74654c003f6d4e32bbef8f5969ee2856394a96d127da4949c65153e",
-    "zh:0472ea1574026aa1e8ca82bb6df2c40cd0478e9336b7a8a64e652119a2fa4f32",
-    "zh:1a8ddba2b1550c5d02003ea5d6cdda2eef6870ece86c5619f33edd699c9dc14b",
-    "zh:1e3bb505c000adb12cdf60af5b08f0ed68bc3955b0d4d4a126db5ca4d429eb4a",
-    "zh:6636401b2463c25e03e68a6b786acf91a311c78444b1dc4f97c539f9f78de22a",
-    "zh:76858f9d8b460e7b2a338c477671d07286b0d287fd2d2e3214030ae8f61dd56e",
-    "zh:a13b69fb43cb8746793b3069c4d897bb18f454290b496f19d03c3387d1c9a2dc",
-    "zh:a90ca81bb9bb509063b736842250ecff0f886a91baae8de65c8430168001dad9",
-    "zh:c4de401395936e41234f1956ebadbd2ed9f414e6908f27d578614aaa529870d4",
-    "zh:c657e121af8fde19964482997f0de2d5173217274f6997e16389e7707ed8ece8",
-    "zh:d68b07a67fbd604c38ec9733069fbf23441436fecf554de6c75c032f82e1ef19",
-    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
-  ]
-}


### PR DESCRIPTION
# Summary
Add provisioned concurrency to the the dedicated sync API lambda function. As part of this change, also refactor the Terraform to avoid the need to duplicate resource blocks for both functions.

# Related
- https://github.com/cds-snc/platform-core-services/issues/548