### PR TITLE
fix: publish a version of the provisioned function

### DIFF
--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -5,7 +5,7 @@ locals {
 module "scan_files" {
   for_each = toset(local.scan_files_api_functions)
 
-  source                 = "github.com/cds-snc/terraform-modules//lambda?ref=v9.2.3"
+  source                 = "github.com/cds-snc/terraform-modules//lambda?ref=v9.2.4"
   name                   = "${var.product_name}-${each.key}"
   billing_tag_value      = var.billing_code
   ecr_arn                = aws_ecr_repository.api.arn
@@ -14,6 +14,7 @@ module "scan_files" {
   memory                 = 3008
   timeout                = 300
   ephemeral_storage      = 768
+  publish                = each.key == "api-provisioned"
 
   vpc = {
     security_group_ids = [module.rds.proxy_security_group_id, aws_security_group.api.id]

--- a/terragrunt/aws/api/moved.tf
+++ b/terragrunt/aws/api/moved.tf
@@ -4,16 +4,6 @@ moved {
 }
 
 moved {
-  from = module.api_provisioned
-  to   = module.scan_files["api-provisioned"]
-}
-
-moved {
   from = aws_lambda_function_url.scan_files_url
   to   = aws_lambda_function_url.scan_files["api"]
-}
-
-moved {
-  from = aws_lambda_function_url.scan_files_provisioned_url
-  to   = aws_lambda_function_url.scan_files["api-provisioned"]
 }


### PR DESCRIPTION
# Summary
Update the API's provisioned Lambda function to publish a version. This is required by provisioned concurrency.

# Related
- https://github.com/cds-snc/platform-core-services/issues/548