### PR TITLE
fix: add function URL qualifier

### DIFF
--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -105,6 +105,7 @@ resource "aws_lambda_function_url" "scan_files" {
 
   function_name      = module.scan_files[each.key].function_name
   authorization_type = "NONE"
+  qualifier          = each.key == "api-provisioned" ? aws_lambda_alias.api_provisioned_latest.name : "$LATEST"
 }
 
 #


### PR DESCRIPTION
# Summary
Update the api-provisioned function URL to reference the `latest` alias that has provisioned concurrency setup.

# Related
- https://github.com/cds-snc/platform-core-services/issues/548