### PR TITLE
fix: omit qualifier for async Scan Files API function

### DIFF
--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -105,7 +105,7 @@ resource "aws_lambda_function_url" "scan_files" {
 
   function_name      = module.scan_files[each.key].function_name
   authorization_type = "NONE"
-  qualifier          = each.key == "api-provisioned" ? aws_lambda_alias.api_provisioned_latest.name : "$LATEST"
+  qualifier          = each.key == "api-provisioned" ? aws_lambda_alias.api_provisioned_latest.name : null
 }
 
 #


### PR DESCRIPTION
# Summary
Update the default async Scan Files API function URL to not have a qualifier specified.

# Related
- https://github.com/cds-snc/platform-core-services/issues/548