### PR TITLE
feat: setup `sync.scan-files.alpha.canada` domain

### DIFF
--- a/terragrunt/aws/api/cloudfront.tf
+++ b/terragrunt/aws/api/cloudfront.tf
@@ -1,12 +1,14 @@
-resource "aws_cloudfront_distribution" "scan_files_api" {
+resource "aws_cloudfront_distribution" "scan_files" {
+  for_each = toset(local.scan_files_api_functions)
+
   enabled     = true
-  aliases     = [var.domain]
+  aliases     = [each.key == "api-provisioned" ? "sync.${var.domain}" : var.domain]
   price_class = "PriceClass_100"
   web_acl_id  = aws_wafv2_web_acl.api_waf.arn
 
   origin {
-    domain_name = split("/", aws_lambda_function_url.scan_files["api"].function_url)[2]
-    origin_id   = aws_lambda_function_url.scan_files["api"].function_name
+    domain_name = split("/", aws_lambda_function_url.scan_files[each.key].function_url)[2]
+    origin_id   = aws_lambda_function_url.scan_files[each.key].function_name
 
     custom_origin_config {
       http_port              = 80
@@ -28,7 +30,7 @@ resource "aws_cloudfront_distribution" "scan_files_api" {
       }
     }
 
-    target_origin_id           = aws_lambda_function_url.scan_files["api"].function_name
+    target_origin_id           = aws_lambda_function_url.scan_files[each.key].function_name
     viewer_protocol_policy     = "redirect-to-https"
     response_headers_policy_id = aws_cloudfront_response_headers_policy.security_headers_policy_api.id
   }
@@ -46,7 +48,7 @@ resource "aws_cloudfront_distribution" "scan_files_api" {
       }
     }
 
-    target_origin_id           = aws_lambda_function_url.scan_files["api"].function_name
+    target_origin_id           = aws_lambda_function_url.scan_files[each.key].function_name
     viewer_protocol_policy     = "redirect-to-https"
     response_headers_policy_id = aws_cloudfront_response_headers_policy.security_headers_policy_api.id
 

--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -1,7 +1,3 @@
-locals {
-  scan_files_api_functions = ["api", "api-provisioned"]
-}
-
 module "scan_files" {
   for_each = toset(local.scan_files_api_functions)
 

--- a/terragrunt/aws/api/locals.tf
+++ b/terragrunt/aws/api/locals.tf
@@ -1,4 +1,5 @@
 locals {
   api_role_arn             = "arn:aws:iam::${var.account_id}:role/${var.product_name}-api"
   cbs_satellite_bucket_arn = "arn:aws:s3:::${var.cbs_satellite_bucket_name}"
+  scan_files_api_functions = ["api", "api-provisioned"]
 }

--- a/terragrunt/aws/api/moved.tf
+++ b/terragrunt/aws/api/moved.tf
@@ -7,3 +7,8 @@ moved {
   from = aws_lambda_function_url.scan_files_url
   to   = aws_lambda_function_url.scan_files["api"]
 }
+
+moved {
+  from = aws_cloudfront_distribution.scan_files_api
+  to   = aws_cloudfront_distribution.scan_files["api"]
+}

--- a/terragrunt/aws/api/outputs.tf
+++ b/terragrunt/aws/api/outputs.tf
@@ -1,5 +1,5 @@
 output "api_cloudfront_distribution_id" {
-  value = aws_cloudfront_distribution.scan_files_api.id
+  value = aws_cloudfront_distribution.scan_files["api"].id
 }
 
 output "vpc_id" {

--- a/terragrunt/aws/api/route53.tf
+++ b/terragrunt/aws/api/route53.tf
@@ -4,8 +4,8 @@ resource "aws_route53_record" "scan_files_A" {
   type    = "A"
 
   alias {
-    name                   = aws_cloudfront_distribution.scan_files_api.domain_name
-    zone_id                = aws_cloudfront_distribution.scan_files_api.hosted_zone_id
+    name                   = aws_cloudfront_distribution.scan_files["api"].domain_name
+    zone_id                = aws_cloudfront_distribution.scan_files["api"].hosted_zone_id
     evaluate_target_health = false
   }
 }
@@ -22,6 +22,18 @@ resource "aws_route53_health_check" "scan_files_A" {
   tags = {
     CostCentre = var.billing_code
     Terraform  = true
+  }
+}
+
+resource "aws_route53_record" "sync_scan_files_A" {
+  zone_id = var.hosted_zone_id
+  name    = "sync.${var.domain}"
+  type    = "A"
+
+  alias {
+    name                   = aws_cloudfront_distribution.scan_files["api-provisioned"].domain_name
+    zone_id                = aws_cloudfront_distribution.scan_files["api-provisioned"].hosted_zone_id
+    evaluate_target_health = false
   }
 }
 


### PR DESCRIPTION
# Summary
Add a CloudFront distribution and WAF association for the provisioned concurrency version of the Scan Files API.

# Related
- https://github.com/cds-snc/platform-core-services/issues/548