### PR TITLE
feat: add `api` module outputs for the provisioned Lambda function

### DIFF
--- a/terragrunt/aws/alarms/inputs.tf
+++ b/terragrunt/aws/alarms/inputs.tf
@@ -3,6 +3,11 @@ variable "api_cloudfront_distribution_id" {
   type        = string
 }
 
+variable "api_sync_cloudfront_distribution_id" {
+  description = "ID of the provisioned API CloudFront distribution"
+  type        = string
+}
+
 variable "route53_health_check_api_id" {
   description = "ID of the API's Route53 health check"
   type        = string
@@ -25,6 +30,11 @@ variable "s3_scan_object_error_threshold" {
 
 variable "scan_files_api_log_group_name" {
   description = "CloudWatch log group name for the Scan Files API lambda function"
+  type        = string
+}
+
+variable "scan_files_api_sync_log_group_name" {
+  description = "CloudWatch log group name for the Scan Files provisioned API lambda function"
   type        = string
 }
 

--- a/terragrunt/aws/api/outputs.tf
+++ b/terragrunt/aws/api/outputs.tf
@@ -2,6 +2,10 @@ output "api_cloudfront_distribution_id" {
   value = aws_cloudfront_distribution.scan_files["api"].id
 }
 
+output "api_sync_cloudfront_distribution_id" {
+  value = aws_cloudfront_distribution.scan_files["api-provisioned"].id
+}
+
 output "vpc_id" {
   value = module.vpc.vpc_id
 }
@@ -14,29 +18,50 @@ output "log_bucket_id" {
   value = module.log_bucket.s3_bucket_id
 }
 
-output "function_arn" {
+output "api_function_arn" {
   value = module.scan_files["api"].function_arn
 }
 
-output "function_log_group_name" {
+output "api_sync_function_arn" {
+  value = module.scan_files["api-provisioned"].function_arn
+}
+
+output "api_function_log_group_name" {
   value = "/aws/lambda/${module.scan_files["api"].function_name}"
 }
 
-output "function_name" {
+output "api_sync_function_log_group_name" {
+  value = "/aws/lambda/${module.scan_files["api-provisioned"].function_name}"
+}
+
+output "api_function_name" {
   value = module.scan_files["api"].function_name
 }
 
-output "function_role_arn" {
+output "api_sync_function_name" {
+  value = module.scan_files["api-provisioned"].function_name
+}
+
+output "api_function_role_arn" {
   value = "arn:aws:iam::${var.account_id}:role/${module.scan_files["api"].function_name}"
 }
 
-output "function_url" {
+output "api_function_url" {
   value     = aws_lambda_function_url.scan_files["api"].function_url
   sensitive = true
 }
 
-output "invoke_arn" {
+output "api_sync_function_url" {
+  value     = aws_lambda_function_url.scan_files["api-provisioned"].function_url
+  sensitive = true
+}
+
+output "api_invoke_arn" {
   value = module.scan_files["api"].invoke_arn
+}
+
+output "api_sync_invoke_arn" {
+  value = module.scan_files["api-provisioned"].invoke_arn
 }
 
 output "route53_health_check_api_id" {

--- a/terragrunt/env/staging/alarms/terragrunt.hcl
+++ b/terragrunt/env/staging/alarms/terragrunt.hcl
@@ -22,9 +22,11 @@ dependency "api" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
-    api_cloudfront_distribution_id = "cloudfront-distribution-id"
-    function_log_group_name        = "/aws/lambda/scan-files-api"
-    route53_health_check_api_id    = ""
+    api_cloudfront_distribution_id      = "api-cloudfront-distribution-id"
+    api_sync_cloudfront_distribution_id = "api-provisioned-cloudfront-distribution-id"
+    api_function_log_group_name         = "/aws/lambda/scan-files-api"
+    api_sync_function_log_group_name    = "/aws/lambda/scan-files-api-provisioned"
+    route53_health_check_api_id         = ""
   }
 }
 
@@ -41,10 +43,12 @@ dependency "s3_scan_object" {
 inputs = {
   route53_hosted_zone_id = dependency.hosted_zone.outputs.hosted_zone_id
 
-  s3_scan_object_log_group_name  = dependency.s3_scan_object.outputs.function_log_group_name
-  scan_files_api_log_group_name  = dependency.api.outputs.function_log_group_name
-  route53_health_check_api_id    = dependency.api.outputs.route53_health_check_api_id
-  api_cloudfront_distribution_id = dependency.api.outputs.api_cloudfront_distribution_id
+  s3_scan_object_log_group_name       = dependency.s3_scan_object.outputs.function_log_group_name
+  scan_files_api_log_group_name       = dependency.api.outputs.api_function_log_group_name
+  scan_files_api_sync_log_group_name  = dependency.api.outputs.api_sync_function_log_group_name
+  route53_health_check_api_id         = dependency.api.outputs.route53_health_check_api_id
+  api_cloudfront_distribution_id      = dependency.api.outputs.api_cloudfront_distribution_id
+  api_sync_cloudfront_distribution_id = dependency.api.outputs.api_sync_cloudfront_distribution_id
 
   s3_scan_object_error_threshold                = "1"
   scan_files_api_error_threshold                = "1"

--- a/terragrunt/env/staging/s3_scan_object/terragrunt.hcl
+++ b/terragrunt/env/staging/s3_scan_object/terragrunt.hcl
@@ -12,17 +12,17 @@ dependency "api" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
-    function_name                 = ""
-    function_role_arn             = ""
-    function_url                  = "http://localhost"
+    api_function_name             = "scan-files-api"
+    api_function_role_arn         = "arn:aws:iam::${local.vars.inputs.account_id}:role/scan-files-api"
+    api_function_url              = "http://localhost"
     scan_files_api_key_secret_arn = ""
   }
 }
 
 inputs = {
-  scan_files_api_function_role_arn  = dependency.api.outputs.function_role_arn
-  scan_files_api_function_role_name = dependency.api.outputs.function_name
-  scan_files_api_function_url       = dependency.api.outputs.function_url
+  scan_files_api_function_role_arn  = dependency.api.outputs.api_function_role_arn
+  scan_files_api_function_role_name = dependency.api.outputs.api_function_name
+  scan_files_api_function_url       = dependency.api.outputs.api_function_url
   scan_files_api_key_secret_arn     = dependency.api.outputs.scan_files_api_key_secret_arn
   sqs_event_accounts                = ["239043911459", "127893201980", "687401027353"]
 }

--- a/terragrunt/env/staging/s3_scan_object/terragrunt.hcl
+++ b/terragrunt/env/staging/s3_scan_object/terragrunt.hcl
@@ -13,7 +13,7 @@ dependency "api" {
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
     api_function_name             = "scan-files-api"
-    api_function_role_arn         = "arn:aws:iam::${local.vars.inputs.account_id}:role/scan-files-api"
+    api_function_role_arn         = "arn:aws:iam::127893201980:role/scan-files-api"
     api_function_url              = "http://localhost"
     scan_files_api_key_secret_arn = ""
   }

--- a/terragrunt/env/staging/scan_queue/terragrunt.hcl
+++ b/terragrunt/env/staging/scan_queue/terragrunt.hcl
@@ -12,7 +12,7 @@ dependency "api" {
   mock_outputs_allowed_terraform_commands = ["validate", "plan"]
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
-    api_function_arn  = "arn:aws:lambda:${local.vars.inputs.region}:${local.vars.inputs.account_id}:function:scan-files-api"
+    api_function_arn  = "arn:aws:lambda:ca-central-1:127893201980:function:scan-files-api"
     api_function_name = "scan-files-api"
   }
 }

--- a/terragrunt/env/staging/scan_queue/terragrunt.hcl
+++ b/terragrunt/env/staging/scan_queue/terragrunt.hcl
@@ -12,15 +12,15 @@ dependency "api" {
   mock_outputs_allowed_terraform_commands = ["validate", "plan"]
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
-    function_arn  = ""
-    function_name = ""
+    api_function_arn  = "arn:aws:lambda:${local.vars.inputs.region}:${local.vars.inputs.account_id}:function:scan-files-api"
+    api_function_name = "scan-files-api"
   }
 }
 
 inputs = {
   concurrent_scan_limit  = 5
-  api_function_arn       = dependency.api.outputs.function_arn
-  api_function_name      = dependency.api.outputs.function_name
+  api_function_arn       = dependency.api.outputs.api_function_arn
+  api_function_name      = dependency.api.outputs.api_function_name
 }
 
 include {


### PR DESCRIPTION
# Summary
Update the outputs so that the sync function values are also made available to dependencies.  As part of this change, the original function's outputs were renamed to make it clear which function they referenced.

# Related
- https://github.com/cds-snc/platform-core-services/issues/548