### PR TITLE
fix: update provisioned API's alias

### DIFF
--- a/.github/workflows/build_and_push_staging.yml
+++ b/.github/workflows/build_and_push_staging.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Update alias for provisioned concurrency API
         if: matrix.image == 'api'
         run: |
-          aws lambda wait function-active --function-name scan-files-api-provisioned
+          aws lambda wait function-updated --function-name scan-files-api-provisioned
           VERSION="$(aws lambda publish-version --function-name scan-files-api-provisioned | jq -r '.Version')"
           aws lambda update-alias \
             --function-name scan-files-api-provisioned \
@@ -108,7 +108,7 @@ jobs:
       - name: API healthcheck
         uses: jtalk/url-health-check-action@61a0e49fff5cde3773b0bbe069d4ebbd04d24f07 # tag=v2
         with:
-          url: https://scan-files.cdssandbox.xyz/version
+          url: https://scan-files.cdssandbox.xyz/version|https://sync.scan-files.cdssandbox.xyz/version
           max-attempts: 3
           retry-delay: 5s
 

--- a/.github/workflows/deploy_lambda_production.yml
+++ b/.github/workflows/deploy_lambda_production.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Update alias for provisioned concurrency API
         if: steps.filter.outputs.changes == 'true' && matrix.function == 'scan-files-api-provisioned'
         run: |
-          aws lambda wait function-active --function-name ${{ matrix.function }}
+          aws lambda wait function-updated --function-name ${{ matrix.function }}
           VERSION="$(aws lambda publish-version --function-name ${{ matrix.function }} | jq -r '.Version')"
           aws lambda update-alias \
             --function-name ${{ matrix.function }} \
@@ -87,6 +87,6 @@ jobs:
         if: steps.filter.outputs.changes == 'true'
         uses: jtalk/url-health-check-action@61a0e49fff5cde3773b0bbe069d4ebbd04d24f07 # tag=v2
         with:
-          url: https://scan-files.alpha.canada.ca/version
+          url: https://scan-files.alpha.canada.ca/version|https://sync.scan-files.alpha.canada.ca/version
           max-attempts: 3
           retry-delay: 5s


### PR DESCRIPTION
# Summary
Update the GitHub workflow to wait until the provisioned API has been updated before updating its alias.

Update the healthcheck step with the new `sync` URL.

# Related
- https://github.com/cds-snc/platform-core-services/issues/548