### PR TITLE
feat: add alarms for the provisioned API function

### DIFF
--- a/terragrunt/aws/alarms/alarms.tf
+++ b/terragrunt/aws/alarms/alarms.tf
@@ -45,7 +45,7 @@ resource "aws_cloudwatch_log_metric_filter" "scan_files_api_error" {
 
   name           = local.error_logged_api
   pattern        = "?ERROR ?Error ?error ?failed"
-  log_group_name = function.value.log_group_name
+  log_group_name = each.value.log_group_name
 
   metric_transformation {
     name      = local.error_logged_api
@@ -59,7 +59,7 @@ resource "aws_cloudwatch_log_metric_filter" "scan_files_api_warning" {
 
   name           = local.warning_logged_api
   pattern        = "WARNING"
-  log_group_name = function.value.log_group_name
+  log_group_name = each.value.log_group_name
 
   metric_transformation {
     name      = local.warning_logged_api
@@ -71,12 +71,12 @@ resource "aws_cloudwatch_log_metric_filter" "scan_files_api_warning" {
 resource "aws_cloudwatch_metric_alarm" "scan_files_api_error" {
   for_each = { for function in local.api_functions : function.name => function }
 
-  alarm_name          = "${local.error_logged_api}-${function.value.name}"
-  alarm_description   = "Errors logged by the Scan Files ${function.value.name} lambda function"
+  alarm_name          = "${local.error_logged_api}-${each.value.name}"
+  alarm_description   = "Errors logged by the Scan Files ${each.value.name} lambda function"
   comparison_operator = "GreaterThanOrEqualToThreshold"
 
-  metric_name        = aws_cloudwatch_log_metric_filter.scan_files_api_error[function.value.name].metric_transformation[0].name
-  namespace          = aws_cloudwatch_log_metric_filter.scan_files_api_error[function.value.name].metric_transformation[0].namespace
+  metric_name        = aws_cloudwatch_log_metric_filter.scan_files_api_error[each.value.name].metric_transformation[0].name
+  namespace          = aws_cloudwatch_log_metric_filter.scan_files_api_error[each.value.name].metric_transformation[0].namespace
   period             = "60"
   evaluation_periods = "1"
   statistic          = "Sum"
@@ -90,12 +90,12 @@ resource "aws_cloudwatch_metric_alarm" "scan_files_api_error" {
 resource "aws_cloudwatch_metric_alarm" "scan_files_api_warning" {
   for_each = { for function in local.api_functions : function.name => function }
 
-  alarm_name          = "${local.warning_logged_api}-${function.value.name}"
-  alarm_description   = "Warnings logged by the Scan Files ${function.value.name} lambda function"
+  alarm_name          = "${local.warning_logged_api}-${each.value.name}"
+  alarm_description   = "Warnings logged by the Scan Files ${each.value.name} lambda function"
   comparison_operator = "GreaterThanOrEqualToThreshold"
 
-  metric_name        = aws_cloudwatch_log_metric_filter.scan_files_api_warning[function.value.name].metric_transformation[0].name
-  namespace          = aws_cloudwatch_log_metric_filter.scan_files_api_warning[function.value.name].metric_transformation[0].namespace
+  metric_name        = aws_cloudwatch_log_metric_filter.scan_files_api_warning[each.value.name].metric_transformation[0].name
+  namespace          = aws_cloudwatch_log_metric_filter.scan_files_api_warning[each.value.name].metric_transformation[0].namespace
   period             = "60"
   evaluation_periods = "1"
   statistic          = "Sum"
@@ -111,7 +111,7 @@ resource "aws_cloudwatch_log_metric_filter" "scan_verdict_unknown" {
 
   name           = local.scan_verdict_unknown
   pattern        = "?unknown ?unable_to_scan"
-  log_group_name = function.value.log_group_name
+  log_group_name = each.value.log_group_name
 
   metric_transformation {
     name      = local.scan_verdict_unknown
@@ -123,11 +123,11 @@ resource "aws_cloudwatch_log_metric_filter" "scan_verdict_unknown" {
 resource "aws_cloudwatch_metric_alarm" "scan_verdict_unknown" {
   for_each = { for function in local.api_functions : function.name => function }
 
-  alarm_name          = "${local.scan_verdict_unknown}-${function.value.name}"
-  alarm_description   = "Scans from the ${function.value.name} that returned an unknown or unable to scan verdict"
+  alarm_name          = "${local.scan_verdict_unknown}-${each.value.name}"
+  alarm_description   = "Scans from the ${each.value.name} that returned an unknown or unable to scan verdict"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  metric_name         = aws_cloudwatch_log_metric_filter.scan_verdict_unknown[function.each.name].metric_transformation[0].name
-  namespace           = aws_cloudwatch_log_metric_filter.scan_verdict_unknown[function.each.name].metric_transformation[0].namespace
+  metric_name         = aws_cloudwatch_log_metric_filter.scan_verdict_unknown[each.value.name].metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.scan_verdict_unknown[each.value.name].metric_transformation[0].namespace
 
   period             = "60"
   evaluation_periods = "1"

--- a/terragrunt/aws/alarms/alarms.tf
+++ b/terragrunt/aws/alarms/alarms.tf
@@ -40,7 +40,7 @@ resource "aws_cloudwatch_metric_alarm" "route53_health_check_api" {
   }
 }
 
-resource "aws_cloudwatch_log_metric_filter" "scan_files_api_error" {
+resource "aws_cloudwatch_log_metric_filter" "scan_files_error" {
   for_each = { for function in local.api_functions : function.name => function }
 
   name           = local.error_logged_api
@@ -54,7 +54,7 @@ resource "aws_cloudwatch_log_metric_filter" "scan_files_api_error" {
   }
 }
 
-resource "aws_cloudwatch_log_metric_filter" "scan_files_api_warning" {
+resource "aws_cloudwatch_log_metric_filter" "scan_files_warning" {
   for_each = { for function in local.api_functions : function.name => function }
 
   name           = local.warning_logged_api
@@ -68,15 +68,15 @@ resource "aws_cloudwatch_log_metric_filter" "scan_files_api_warning" {
   }
 }
 
-resource "aws_cloudwatch_metric_alarm" "scan_files_api_error" {
+resource "aws_cloudwatch_metric_alarm" "scan_files_error" {
   for_each = { for function in local.api_functions : function.name => function }
 
   alarm_name          = "${local.error_logged_api}-${each.value.name}"
   alarm_description   = "Errors logged by the Scan Files ${each.value.name} lambda function"
   comparison_operator = "GreaterThanOrEqualToThreshold"
 
-  metric_name        = aws_cloudwatch_log_metric_filter.scan_files_api_error[each.value.name].metric_transformation[0].name
-  namespace          = aws_cloudwatch_log_metric_filter.scan_files_api_error[each.value.name].metric_transformation[0].namespace
+  metric_name        = aws_cloudwatch_log_metric_filter.scan_files_error[each.value.name].metric_transformation[0].name
+  namespace          = aws_cloudwatch_log_metric_filter.scan_files_error[each.value.name].metric_transformation[0].namespace
   period             = "60"
   evaluation_periods = "1"
   statistic          = "Sum"
@@ -87,15 +87,15 @@ resource "aws_cloudwatch_metric_alarm" "scan_files_api_error" {
   ok_actions    = [aws_sns_topic.cloudwatch_warning.arn]
 }
 
-resource "aws_cloudwatch_metric_alarm" "scan_files_api_warning" {
+resource "aws_cloudwatch_metric_alarm" "scan_files_warning" {
   for_each = { for function in local.api_functions : function.name => function }
 
   alarm_name          = "${local.warning_logged_api}-${each.value.name}"
   alarm_description   = "Warnings logged by the Scan Files ${each.value.name} lambda function"
   comparison_operator = "GreaterThanOrEqualToThreshold"
 
-  metric_name        = aws_cloudwatch_log_metric_filter.scan_files_api_warning[each.value.name].metric_transformation[0].name
-  namespace          = aws_cloudwatch_log_metric_filter.scan_files_api_warning[each.value.name].metric_transformation[0].namespace
+  metric_name        = aws_cloudwatch_log_metric_filter.scan_files_warning[each.value.name].metric_transformation[0].name
+  namespace          = aws_cloudwatch_log_metric_filter.scan_files_warning[each.value.name].metric_transformation[0].namespace
   period             = "60"
   evaluation_periods = "1"
   statistic          = "Sum"

--- a/terragrunt/aws/alarms/alarms.tf
+++ b/terragrunt/aws/alarms/alarms.tf
@@ -1,10 +1,20 @@
 locals {
-  error_logged_api            = "ErrorLoggedAPI"
+  api_functions = [
+    {
+      name           = "api",
+      log_group_name = var.scan_files_api_log_group_name,
+    },
+    {
+      name           = "api-provisioned",
+      log_group_name = var.scan_files_api_sync_log_group_name,
+    },
+  ]
+  error_logged_api            = "ErrorLogged"
   error_logged_s3_scan_object = "ErrorLoggedS3ScanObject"
   error_namespace             = "ScanFiles"
   scan_verdict_suspicious     = "ScanVerdictSuspicious"
   scan_verdict_unknown        = "ScanVerdictUnknown"
-  warning_logged_api          = "WarningLoggedAPI"
+  warning_logged_api          = "WarningLogged"
 }
 
 resource "aws_cloudwatch_metric_alarm" "route53_health_check_api" {
@@ -31,9 +41,11 @@ resource "aws_cloudwatch_metric_alarm" "route53_health_check_api" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "scan_files_api_error" {
+  for_each = { for function in local.api_functions : function.name => function }
+
   name           = local.error_logged_api
   pattern        = "?ERROR ?Error ?error ?failed"
-  log_group_name = var.scan_files_api_log_group_name
+  log_group_name = function.value.log_group_name
 
   metric_transformation {
     name      = local.error_logged_api
@@ -43,9 +55,11 @@ resource "aws_cloudwatch_log_metric_filter" "scan_files_api_error" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "scan_files_api_warning" {
+  for_each = { for function in local.api_functions : function.name => function }
+
   name           = local.warning_logged_api
   pattern        = "WARNING"
-  log_group_name = var.scan_files_api_log_group_name
+  log_group_name = function.value.log_group_name
 
   metric_transformation {
     name      = local.warning_logged_api
@@ -55,12 +69,14 @@ resource "aws_cloudwatch_log_metric_filter" "scan_files_api_warning" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "scan_files_api_error" {
-  alarm_name          = local.error_logged_api
-  alarm_description   = "Errors logged by the Scan Files API lambda function"
+  for_each = { for function in local.api_functions : function.name => function }
+
+  alarm_name          = "${local.error_logged_api}-${function.value.name}"
+  alarm_description   = "Errors logged by the Scan Files ${function.value.name} lambda function"
   comparison_operator = "GreaterThanOrEqualToThreshold"
 
-  metric_name        = aws_cloudwatch_log_metric_filter.scan_files_api_error.metric_transformation[0].name
-  namespace          = aws_cloudwatch_log_metric_filter.scan_files_api_error.metric_transformation[0].namespace
+  metric_name        = aws_cloudwatch_log_metric_filter.scan_files_api_error[function.value.name].metric_transformation[0].name
+  namespace          = aws_cloudwatch_log_metric_filter.scan_files_api_error[function.value.name].metric_transformation[0].namespace
   period             = "60"
   evaluation_periods = "1"
   statistic          = "Sum"
@@ -72,12 +88,14 @@ resource "aws_cloudwatch_metric_alarm" "scan_files_api_error" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "scan_files_api_warning" {
-  alarm_name          = local.warning_logged_api
-  alarm_description   = "Warnings logged by the Scan Files API lambda function"
+  for_each = { for function in local.api_functions : function.name => function }
+
+  alarm_name          = "${local.warning_logged_api}-${function.value.name}"
+  alarm_description   = "Warnings logged by the Scan Files ${function.value.name} lambda function"
   comparison_operator = "GreaterThanOrEqualToThreshold"
 
-  metric_name        = aws_cloudwatch_log_metric_filter.scan_files_api_warning.metric_transformation[0].name
-  namespace          = aws_cloudwatch_log_metric_filter.scan_files_api_warning.metric_transformation[0].namespace
+  metric_name        = aws_cloudwatch_log_metric_filter.scan_files_api_warning[function.value.name].metric_transformation[0].name
+  namespace          = aws_cloudwatch_log_metric_filter.scan_files_api_warning[function.value.name].metric_transformation[0].namespace
   period             = "60"
   evaluation_periods = "1"
   statistic          = "Sum"
@@ -89,9 +107,11 @@ resource "aws_cloudwatch_metric_alarm" "scan_files_api_warning" {
 }
 
 resource "aws_cloudwatch_log_metric_filter" "scan_verdict_unknown" {
+  for_each = { for function in local.api_functions : function.name => function }
+
   name           = local.scan_verdict_unknown
   pattern        = "?unknown ?unable_to_scan"
-  log_group_name = var.scan_files_api_log_group_name
+  log_group_name = function.value.log_group_name
 
   metric_transformation {
     name      = local.scan_verdict_unknown
@@ -101,11 +121,13 @@ resource "aws_cloudwatch_log_metric_filter" "scan_verdict_unknown" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "scan_verdict_unknown" {
-  alarm_name          = local.scan_verdict_unknown
-  alarm_description   = "Scans that returned an unknown or unable to scan verdict"
+  for_each = { for function in local.api_functions : function.name => function }
+
+  alarm_name          = "${local.scan_verdict_unknown}-${function.value.name}"
+  alarm_description   = "Scans from the ${function.value.name} that returned an unknown or unable to scan verdict"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  metric_name         = aws_cloudwatch_log_metric_filter.scan_verdict_unknown.metric_transformation[0].name
-  namespace           = aws_cloudwatch_log_metric_filter.scan_verdict_unknown.metric_transformation[0].namespace
+  metric_name         = aws_cloudwatch_log_metric_filter.scan_verdict_unknown[function.each.name].metric_transformation[0].name
+  namespace           = aws_cloudwatch_log_metric_filter.scan_verdict_unknown[function.each.name].metric_transformation[0].namespace
 
   period             = "60"
   evaluation_periods = "1"

--- a/terragrunt/aws/alarms/dashboards/ops.json
+++ b/terragrunt/aws/alarms/dashboards/ops.json
@@ -9,7 +9,7 @@
             "properties": {
                 "title": "Alarms",
                 "alarms": [
-                    "arn:aws:cloudwatch:ca-central-1:${account_id}:alarm:ErrorLoggedAPI",
+                    "arn:aws:cloudwatch:ca-central-1:${account_id}:alarm:ErrorLogged-api",
                     "arn:aws:cloudwatch:ca-central-1:${account_id}:alarm:ErrorLoggedS3ScanObject",
                     "arn:aws:cloudwatch:ca-central-1:${account_id}:alarm:ScanVerdictSuspicious"
                 ]

--- a/terragrunt/aws/alarms/inputs.tf
+++ b/terragrunt/aws/alarms/inputs.tf
@@ -3,6 +3,11 @@ variable "api_cloudfront_distribution_id" {
   type        = string
 }
 
+variable "api_sync_cloudfront_distribution_id" {
+  description = "ID of the provisioned API CloudFront distribution"
+  type        = string
+}
+
 variable "route53_health_check_api_id" {
   description = "ID of the API's Route53 health check"
   type        = string
@@ -25,6 +30,11 @@ variable "s3_scan_object_error_threshold" {
 
 variable "scan_files_api_log_group_name" {
   description = "CloudWatch log group name for the Scan Files API lambda function"
+  type        = string
+}
+
+variable "scan_files_api_sync_log_group_name" {
+  description = "CloudWatch log group name for the Scan Files provisioned API lambda function"
   type        = string
 }
 

--- a/terragrunt/aws/alarms/shield_advanced.tf
+++ b/terragrunt/aws/alarms/shield_advanced.tf
@@ -8,7 +8,7 @@ resource "aws_shield_protection" "cloudfront_api" {
   }
 }
 
-resource "aws_shield_protection" "cloudfront_api" {
+resource "aws_shield_protection" "cloudfront_api_sync" {
   name         = "CloudFrontAPISync"
   resource_arn = "arn:aws:cloudfront::${var.account_id}:distribution/${var.api_sync_cloudfront_distribution_id}"
 

--- a/terragrunt/aws/alarms/shield_advanced.tf
+++ b/terragrunt/aws/alarms/shield_advanced.tf
@@ -8,6 +8,16 @@ resource "aws_shield_protection" "cloudfront_api" {
   }
 }
 
+resource "aws_shield_protection" "cloudfront_api" {
+  name         = "CloudFrontAPISync"
+  resource_arn = "arn:aws:cloudfront::${var.account_id}:distribution/${var.api_sync_cloudfront_distribution_id}"
+
+  tags = {
+    CostCentre = var.billing_code
+    Terraform  = true
+  }
+}
+
 resource "aws_shield_protection" "route53_hosted_zone" {
   name         = "Route53HostedZone"
   resource_arn = "arn:aws:route53:::hostedzone/${var.route53_hosted_zone_id}"

--- a/terragrunt/env/production/alarms/terragrunt.hcl
+++ b/terragrunt/env/production/alarms/terragrunt.hcl
@@ -22,9 +22,11 @@ dependency "api" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
-    api_cloudfront_distribution_id = "cloudfront-distribution-id"
-    function_log_group_name        = "/aws/lambda/scan-files-api"
-    route53_health_check_api_id    = ""
+    api_cloudfront_distribution_id      = "api-cloudfront-distribution-id"
+    api_sync_cloudfront_distribution_id = "api-provisioned-cloudfront-distribution-id"
+    api_function_log_group_name         = "/aws/lambda/scan-files-api"
+    api_sync_function_log_group_name    = "/aws/lambda/scan-files-api-provisioned"
+    route53_health_check_api_id         = ""
   }
 }
 
@@ -41,10 +43,12 @@ dependency "s3_scan_object" {
 inputs = {
   route53_hosted_zone_id = dependency.hosted_zone.outputs.hosted_zone_id
 
-  s3_scan_object_log_group_name  = dependency.s3_scan_object.outputs.function_log_group_name
-  scan_files_api_log_group_name  = dependency.api.outputs.function_log_group_name
-  route53_health_check_api_id    = dependency.api.outputs.route53_health_check_api_id
-  api_cloudfront_distribution_id = dependency.api.outputs.api_cloudfront_distribution_id
+  s3_scan_object_log_group_name       = dependency.s3_scan_object.outputs.function_log_group_name
+  scan_files_api_log_group_name       = dependency.api.outputs.api_function_log_group_name
+  scan_files_api_sync_log_group_name  = dependency.api.outputs.api_sync_function_log_group_name
+  route53_health_check_api_id         = dependency.api.outputs.route53_health_check_api_id
+  api_cloudfront_distribution_id      = dependency.api.outputs.api_cloudfront_distribution_id
+  api_sync_cloudfront_distribution_id = dependency.api.outputs.api_sync_cloudfront_distribution_id
 
   s3_scan_object_error_threshold                = "1"
   scan_files_api_error_threshold                = "1"

--- a/terragrunt/env/production/s3_scan_object/terragrunt.hcl
+++ b/terragrunt/env/production/s3_scan_object/terragrunt.hcl
@@ -12,17 +12,17 @@ dependency "api" {
   mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
-    function_name                 = ""
-    function_role_arn             = ""
-    function_url                  = "http://localhost"
+    api_function_name             = "scan-files-api"
+    api_function_role_arn         = "arn:aws:iam::806545929748:role/scan-files-api"
+    api_function_url              = "http://localhost"
     scan_files_api_key_secret_arn = ""
   }
 }
 
 inputs = {
-  scan_files_api_function_role_arn  = dependency.api.outputs.function_role_arn
-  scan_files_api_function_role_name = dependency.api.outputs.function_name
-  scan_files_api_function_url       = dependency.api.outputs.function_url
+  scan_files_api_function_role_arn  = dependency.api.outputs.api_function_role_arn
+  scan_files_api_function_role_name = dependency.api.outputs.api_function_name
+  scan_files_api_function_url       = dependency.api.outputs.api_function_url
   scan_files_api_key_secret_arn     = dependency.api.outputs.scan_files_api_key_secret_arn
   sqs_event_accounts                = ["296255494825", "806545929748", "957818836222"]
 }

--- a/terragrunt/env/production/scan_queue/terragrunt.hcl
+++ b/terragrunt/env/production/scan_queue/terragrunt.hcl
@@ -12,15 +12,15 @@ dependency "api" {
   mock_outputs_allowed_terraform_commands = ["validate", "plan"]
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
-    function_arn  = ""
-    function_name = ""
+    api_function_arn  = "arn:aws:lambda:ca-central-1:806545929748:function:scan-files-api"
+    api_function_name = "scan-files-api"
   }
 }
 
 inputs = {
   concurrent_scan_limit  = 5
-  api_function_arn       = dependency.api.outputs.function_arn
-  api_function_name      = dependency.api.outputs.function_name
+  api_function_arn       = dependency.api.outputs.api_function_arn
+  api_function_name      = dependency.api.outputs.api_function_name
 }
 
 include {


### PR DESCRIPTION
# Summary
Add CloudWatch alarms for the provisioned API lambda function.

Update the production `terragrunt.hcl` files with the new `api` outputs.

# Related
- https://github.com/cds-snc/platform-core-services/issues/548