### PR TITLE
fix: update scan_squeue terragrunt mock commands

### DIFF
--- a/terragrunt/env/production/scan_queue/terragrunt.hcl
+++ b/terragrunt/env/production/scan_queue/terragrunt.hcl
@@ -9,7 +9,7 @@ dependencies {
 dependency "api" {
   config_path = "../api"
 
-  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
     api_function_arn  = "arn:aws:lambda:ca-central-1:806545929748:function:scan-files-api"

--- a/terragrunt/env/staging/scan_queue/terragrunt.hcl
+++ b/terragrunt/env/staging/scan_queue/terragrunt.hcl
@@ -9,7 +9,7 @@ dependencies {
 dependency "api" {
   config_path = "../api"
 
-  mock_outputs_allowed_terraform_commands = ["validate", "plan"]
+  mock_outputs_allowed_terraform_commands = ["init", "fmt", "validate", "plan", "show"]
   mock_outputs_merge_strategy_with_state  = "shallow"
   mock_outputs = {
     api_function_arn  = "arn:aws:lambda:ca-central-1:127893201980:function:scan-files-api"


### PR DESCRIPTION
# Summary
Update the state mock commands so that the module plans properly when new mock outputs are added.

# Related
- https://github.com/cds-snc/platform-core-services/issues/548