### PR TITLE
chore: suppress missing patch CloudWatch alarms

### DIFF
--- a/terragrunt/aws/alarms/alarms.tf
+++ b/terragrunt/aws/alarms/alarms.tf
@@ -1,22 +1,3 @@
-locals {
-  api_functions = [
-    {
-      name           = "api",
-      log_group_name = var.scan_files_api_log_group_name,
-    },
-    {
-      name           = "api-provisioned",
-      log_group_name = var.scan_files_api_sync_log_group_name,
-    },
-  ]
-  error_logged_api            = "ErrorLogged"
-  error_logged_s3_scan_object = "ErrorLoggedS3ScanObject"
-  error_namespace             = "ScanFiles"
-  scan_verdict_suspicious     = "ScanVerdictSuspicious"
-  scan_verdict_unknown        = "ScanVerdictUnknown"
-  warning_logged_api          = "WarningLogged"
-}
-
 resource "aws_cloudwatch_metric_alarm" "route53_health_check_api" {
   provider = aws.us-east-1
 
@@ -44,7 +25,7 @@ resource "aws_cloudwatch_log_metric_filter" "scan_files_error" {
   for_each = { for function in local.api_functions : function.name => function }
 
   name           = local.error_logged_api
-  pattern        = "?ERROR ?Error ?error ?failed"
+  pattern        = local.api_error_metric_pattern
   log_group_name = each.value.log_group_name
 
   metric_transformation {
@@ -58,7 +39,7 @@ resource "aws_cloudwatch_log_metric_filter" "scan_files_warning" {
   for_each = { for function in local.api_functions : function.name => function }
 
   name           = local.warning_logged_api
-  pattern        = "WARNING"
+  pattern        = local.api_warning_metric_pattern
   log_group_name = each.value.log_group_name
 
   metric_transformation {

--- a/terragrunt/aws/alarms/locals.tf
+++ b/terragrunt/aws/alarms/locals.tf
@@ -1,0 +1,38 @@
+locals {
+  api_functions = [
+    {
+      name           = "api",
+      log_group_name = var.scan_files_api_log_group_name,
+    },
+    {
+      name           = "api-provisioned",
+      log_group_name = var.scan_files_api_sync_log_group_name,
+    },
+  ]
+  error_logged_api            = "ErrorLogged"
+  error_logged_s3_scan_object = "ErrorLoggedS3ScanObject"
+  error_namespace             = "ScanFiles"
+  scan_verdict_suspicious     = "ScanVerdictSuspicious"
+  scan_verdict_unknown        = "ScanVerdictUnknown"
+  warning_logged_api          = "WarningLogged"
+
+  # Metric filter patterns
+  api_errors = [
+    "ERROR",
+    "Error",
+    "error",
+    "failed",
+  ]
+  api_errors_skip = [
+    "database server doesn't have the latest patch",
+  ]
+  api_warnings = [
+    "Warning",
+    "warning",
+  ]
+  api_warnings_skip = [
+    "database server doesn't have the latest patch",
+  ]
+  api_error_metric_pattern   = "[(w1=\"*${join("*\" || w1=\"*", local.api_errors)}*\") && w1!=\"*${join("*\" && w1!=\"*", local.api_errors_skip)}*\"]"
+  api_warning_metric_pattern = "[(w1=\"*${join("*\" || w1=\"*", local.api_warnings)}*\") && w1!=\"*${join("*\" && w1!=\"*", local.api_warnings_skip)}*\"]"
+}


### PR DESCRIPTION
# Summary
Update the API's CloudWatch error and warning alarms to no longer trigger if there is a missing update patch.

This is caused by the target ClamAV update server not having a patch available yet and will resolve on its own.

# Related
- https://github.com/cds-snc/scan-files/issues/901