### PR TITLE
fix: add missing `WARNING` token to API alarm

### DIFF
--- a/terragrunt/aws/alarms/locals.tf
+++ b/terragrunt/aws/alarms/locals.tf
@@ -27,6 +27,7 @@ locals {
     "database server doesn't have the latest patch",
   ]
   api_warnings = [
+    "WARNING",
     "Warning",
     "warning",
   ]


### PR DESCRIPTION
# Summary
Add the missing `WARNING` token from the API's warning CloudWatch alarm metric filter.

# Related
- #902 
- https://github.com/cds-snc/scan-files/issues/901