### PR TITLE
chore: suppress AWS Lambda Powertools metrics warning

### DIFF
--- a/terragrunt/aws/alarms/locals.tf
+++ b/terragrunt/aws/alarms/locals.tf
@@ -33,6 +33,7 @@ locals {
   ]
   api_warnings_skip = [
     "database server doesn't have the latest patch",
+    "No application metrics to publish",
   ]
   api_error_metric_pattern   = "[(w1=\"*${join("*\" || w1=\"*", local.api_errors)}*\") && w1!=\"*${join("*\" && w1!=\"*", local.api_errors_skip)}*\"]"
   api_warning_metric_pattern = "[(w1=\"*${join("*\" || w1=\"*", local.api_warnings)}*\") && w1!=\"*${join("*\" && w1!=\"*", local.api_warnings_skip)}*\"]"


### PR DESCRIPTION
# Summary | Résumé
Update the API CloudWatch warning metric filter to ignore messages that there are no metrics to publish.