### PR TITLE
fix: API metric error names

### DIFF
--- a/terragrunt/aws/alarms/alarms.tf
+++ b/terragrunt/aws/alarms/alarms.tf
@@ -24,7 +24,7 @@ resource "aws_cloudwatch_metric_alarm" "route53_health_check_api" {
 resource "aws_cloudwatch_log_metric_filter" "scan_files_error" {
   for_each = { for function in local.api_functions : function.name => function }
 
-  name           = local.error_logged_api
+  name           = "${local.error_logged_api}-${each.value.name}"
   pattern        = local.api_error_metric_pattern
   log_group_name = each.value.log_group_name
 
@@ -38,7 +38,7 @@ resource "aws_cloudwatch_log_metric_filter" "scan_files_error" {
 resource "aws_cloudwatch_log_metric_filter" "scan_files_warning" {
   for_each = { for function in local.api_functions : function.name => function }
 
-  name           = local.warning_logged_api
+  name           = "${local.warning_logged_api}-${each.value.name}"
   pattern        = local.api_warning_metric_pattern
   log_group_name = each.value.log_group_name
 
@@ -90,7 +90,7 @@ resource "aws_cloudwatch_metric_alarm" "scan_files_warning" {
 resource "aws_cloudwatch_log_metric_filter" "scan_verdict_unknown" {
   for_each = { for function in local.api_functions : function.name => function }
 
-  name           = local.scan_verdict_unknown
+  name           = "${local.scan_verdict_unknown}-${each.value.name}"
   pattern        = "?unknown ?unable_to_scan"
   log_group_name = each.value.log_group_name
 

--- a/terragrunt/aws/alarms/locals.tf
+++ b/terragrunt/aws/alarms/locals.tf
@@ -24,7 +24,7 @@ locals {
     "failed",
   ]
   api_errors_skip = [
-    "database server doesn't have the latest patch",
+    "No application metrics to publish",
   ]
   api_warnings = [
     "WARNING",
@@ -32,7 +32,6 @@ locals {
     "warning",
   ]
   api_warnings_skip = [
-    "database server doesn't have the latest patch",
     "No application metrics to publish",
   ]
   api_error_metric_pattern   = "[(w1=\"*${join("*\" || w1=\"*", local.api_errors)}*\") && w1!=\"*${join("*\" && w1!=\"*", local.api_errors_skip)}*\"]"


### PR DESCRIPTION
# Summary
Update the API CloudWatch metric names to create a metric for each API function.

Also removes the skip filter on the missing database patch.