### PR TITLE
fix: disable scan result cache check

### DIFF
--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -20,6 +20,7 @@ module "scan_files" {
   environment_variables = {
     API_AUTH_TOKEN_SECRET_ARN    = aws_secretsmanager_secret.api_auth_token.id
     AV_DEFINITION_S3_BUCKET      = "${var.product_name}-${var.env}-clamav-defs"
+    AV_SCAN_USE_CACHE            = "False"
     AWS_MAX_ATTEMPTS             = "5"
     AWS_RETRY_MODE               = "standard"
     COMPLETED_SCANS_TABLE_NAME   = "completed-scans"


### PR DESCRIPTION
# Summary
Update the API to no longer attempt to use cached scan results.  This is because the feature is not proving useful for the Notify use case where most attachments are unique.

Additionally during heavy Notify sends, the cache result lookup is causing database connection exhaustion errors.
