### PR TITLE
fix: remove `in_progress` stan status tag

### DIFF
--- a/module/s3-scan-object/app.js
+++ b/module/s3-scan-object/app.js
@@ -168,9 +168,15 @@ const processEventRecords = async (event, apiKey) => {
     if (scanStatus !== null) {
       let tags = [
         { Key: "av-scanner", Value: "clamav" },
-        { Key: "av-status", Value: scanStatus },
         { Key: "av-timestamp", Value: new Date().getTime() },
       ];
+
+      // Only tag the scan status if it's not in progress.  We are seeing race conditions where a
+      // finished scan result is being overwritten by the in progress status.  Going forward, the precense of
+      // scan metadata with no status will be considered in progress.
+      if (scanStatus !== SCAN_IN_PROGRESS) {
+        tags.push({ Key: "av-status", Value: scanStatus });
+      }
 
       if (scanChecksum && scanChecksum !== "None") {
         tags.push({ Key: "av-checksum", Value: scanChecksum });

--- a/module/s3-scan-object/app.test.js
+++ b/module/s3-scan-object/app.test.js
@@ -110,7 +110,6 @@ describe("processEventRecords", () => {
       Tagging: {
         TagSet: [
           { Key: "av-scanner", Value: "clamav" },
-          { Key: "av-status", Value: "in_progress" },
           { Key: "av-timestamp", Value: TEST_TIME },
           { Key: "request-id", Value: "1234asdf" },
         ],
@@ -122,8 +121,8 @@ describe("processEventRecords", () => {
       Tagging: {
         TagSet: [
           { Key: "av-scanner", Value: "clamav" },
-          { Key: "av-status", Value: "SPIFY" },
           { Key: "av-timestamp", Value: TEST_TIME },
+          { Key: "av-status", Value: "SPIFY" },
           { Key: "av-checksum", Value: "42" },
           { Key: "request-id", Value: "zxcv9584" },
         ],
@@ -135,7 +134,6 @@ describe("processEventRecords", () => {
       Tagging: {
         TagSet: [
           { Key: "av-scanner", Value: "clamav" },
-          { Key: "av-status", Value: "in_progress" },
           { Key: "av-timestamp", Value: TEST_TIME },
           { Key: "request-id", Value: "zxcv9584" },
         ],
@@ -147,8 +145,8 @@ describe("processEventRecords", () => {
       Tagging: {
         TagSet: [
           { Key: "av-scanner", Value: "clamav" },
-          { Key: "av-status", Value: "error" },
           { Key: "av-timestamp", Value: TEST_TIME },
+          { Key: "av-status", Value: "error" },
           { Key: "request-id", Value: "poiu0987" },
         ],
       },
@@ -159,7 +157,6 @@ describe("processEventRecords", () => {
       Tagging: {
         TagSet: [
           { Key: "av-scanner", Value: "clamav" },
-          { Key: "av-status", Value: "in_progress" },
           { Key: "av-timestamp", Value: TEST_TIME },
           { Key: "request-id", Value: "0987" },
         ],
@@ -171,7 +168,6 @@ describe("processEventRecords", () => {
       Tagging: {
         TagSet: [
           { Key: "av-scanner", Value: "clamav" },
-          { Key: "av-status", Value: "in_progress" },
           { Key: "av-timestamp", Value: TEST_TIME },
           { Key: "request-id", Value: "0987" },
         ],
@@ -218,8 +214,8 @@ describe("processEventRecords", () => {
       Tagging: {
         TagSet: [
           { Key: "av-scanner", Value: "clamav" },
-          { Key: "av-status", Value: "failed_to_start" },
           { Key: "av-timestamp", Value: TEST_TIME },
+          { Key: "av-status", Value: "failed_to_start" },
           { Key: "request-id", Value: "qwer7890" },
         ],
       },
@@ -257,8 +253,8 @@ describe("processEventRecords", () => {
       Tagging: {
         TagSet: [
           { Key: "av-scanner", Value: "clamav" },
-          { Key: "av-status", Value: "failed_to_start" },
           { Key: "av-timestamp", Value: TEST_TIME },
+          { Key: "av-status", Value: "failed_to_start" },
           { Key: "request-id", Value: "zxcv5678" },
         ],
       },


### PR DESCRIPTION
# Summary
Update the s3-scan-object module to no longer tag objects with an `in_progress` scan status.  We have started seeing race conditions where the `in_progress` tag is overwriting final scan status tags.

Going forward, scan metadata without an `av-status` will be considered an in progress scan.

# Related
- https://github.com/cds-snc/platform-core-services/issues/585