### PR TITLE
fix: remove in progress S3 objec tags

### DIFF
--- a/module/s3-scan-object/README.md
+++ b/module/s3-scan-object/README.md
@@ -8,7 +8,7 @@ The following S3 object tags are used to communicate the scan results:
 
 - `av-checksum`: Checksum of the file that was scanned.
 - `av-result`: The scan result verdict from ClamAV.
-- `av-status`: The status of the scan (in_progress, failed_to_start, complete).
+- `av-status`: The status of the scan (failed_to_start, clean, malicious).
 - `av-timestamp`: Epoch timestamp of when the tags were set.
 
 # Events

--- a/module/s3-scan-object/app.test.js
+++ b/module/s3-scan-object/app.test.js
@@ -105,17 +105,6 @@ describe("processEventRecords", () => {
     const errorCount = await processEventRecords(event, "api-key");
     expect(errorCount).toEqual(0);
     expect(mockS3Client).toHaveReceivedNthCommandWith(1, PutObjectTaggingCommand, {
-      Bucket: "foo",
-      Key: "bar",
-      Tagging: {
-        TagSet: [
-          { Key: "av-scanner", Value: "clamav" },
-          { Key: "av-timestamp", Value: TEST_TIME },
-          { Key: "request-id", Value: "1234asdf" },
-        ],
-      },
-    });
-    expect(mockS3Client).toHaveReceivedNthCommandWith(2, PutObjectTaggingCommand, {
       Bucket: "bam",
       Key: "baz",
       Tagging: {
@@ -128,18 +117,7 @@ describe("processEventRecords", () => {
         ],
       },
     });
-    expect(mockS3Client).toHaveReceivedNthCommandWith(3, PutObjectTaggingCommand, {
-      Bucket: "boom",
-      Key: "bing",
-      Tagging: {
-        TagSet: [
-          { Key: "av-scanner", Value: "clamav" },
-          { Key: "av-timestamp", Value: TEST_TIME },
-          { Key: "request-id", Value: "zxcv9584" },
-        ],
-      },
-    });
-    expect(mockS3Client).toHaveReceivedNthCommandWith(4, PutObjectTaggingCommand, {
+    expect(mockS3Client).toHaveReceivedNthCommandWith(2, PutObjectTaggingCommand, {
       Bucket: "frodo",
       Key: "bagginsssis",
       Tagging: {
@@ -151,38 +129,12 @@ describe("processEventRecords", () => {
         ],
       },
     });
-    expect(mockS3Client).toHaveReceivedNthCommandWith(5, PutObjectTaggingCommand, {
-      Bucket: "muffins",
-      Key: "blueberry",
-      Tagging: {
-        TagSet: [
-          { Key: "av-scanner", Value: "clamav" },
-          { Key: "av-timestamp", Value: TEST_TIME },
-          { Key: "request-id", Value: "0987" },
-        ],
-      },
-    });
-    expect(mockS3Client).toHaveReceivedNthCommandWith(6, PutObjectTaggingCommand, {
-      Bucket: "scones",
-      Key: "cranberry",
-      Tagging: {
-        TagSet: [
-          { Key: "av-scanner", Value: "clamav" },
-          { Key: "av-timestamp", Value: TEST_TIME },
-          { Key: "request-id", Value: "0987" },
-        ],
-      },
-    });
     expect(mockSTSClient).toHaveReceivedNthCommandWith(1, AssumeRoleCommand, {
       RoleArn: "arn:aws:iam::123456789012:role/ScanFilesGetObjects",
       RoleSessionName: "s3-scan-object",
     });
     expect(mockSTSClient).toHaveReceivedNthCommandWith(2, AssumeRoleCommand, {
       RoleArn: "arn:aws:iam::210987654321:role/ScanFilesGetObjects",
-      RoleSessionName: "s3-scan-object",
-    });
-    expect(mockSTSClient).toHaveReceivedNthCommandWith(3, AssumeRoleCommand, {
-      RoleArn: "arn:aws:iam::098765432109:role/ScanFilesGetObjects",
       RoleSessionName: "s3-scan-object",
     });
   });


### PR DESCRIPTION
# Summary
Update the `s3-scan-object` module so that in progress S3 object tags are no longer added.  These have been removed because in rare cases we were seeing race conditions where the in progress tagging operation overwrote the scan complete tags.

This occurs because S3 tag operations always replace all tags on an object with the new TagSet in the request.

# Related
- https://github.com/cds-snc/platform-core-services/issues/585