### PR TITLE
fix: add ability to suppress PUA findings

### DIFF
--- a/api/clamav_scanner/clamav.py
+++ b/api/clamav_scanner/clamav.py
@@ -18,6 +18,7 @@ from .common import AV_DEFINITION_PATH
 from .common import AV_DEFINITION_FILE_PREFIXES
 from .common import AV_DEFINITION_FILE_SUFFIXES
 from .common import AV_SCAN_USE_CACHE
+from .common import AV_SIGNATURE_FALSE_POSITIVES
 from .common import AV_SIGNATURE_UNKNOWN
 from .common import AV_SIGNATURE_METADATA
 from .common import CLAMD_STARTUP_LOCK
@@ -291,7 +292,10 @@ def determine_verdict(provider, path, summary, av_proc):
             log.error("Unable to scan file: %s" % path)
             return ScanVerdicts.UNABLE_TO_SCAN.value, AV_SIGNATURE_UNKNOWN
 
-        if av_proc.returncode == 0:
+        if av_proc.returncode == 0 or any(
+            false_positive in signature
+            for false_positive in AV_SIGNATURE_FALSE_POSITIVES
+        ):
             return ScanVerdicts.CLEAN.value, signature
         elif av_proc.returncode == 1:
             return ScanVerdicts.MALICIOUS.value, signature

--- a/api/clamav_scanner/common.py
+++ b/api/clamav_scanner/common.py
@@ -12,6 +12,10 @@ AV_DEFINITION_PATH = os.getenv(
 AV_SCAN_USE_CACHE = os.getenv("AV_SCAN_USE_CACHE", "True") in ("True", "true")
 AV_SCAN_START_SNS_ARN = os.getenv("AV_SCAN_START_SNS_ARN")
 AV_SCAN_START_METADATA = os.getenv("AV_SCAN_START_METADATA", "av-scan-start")
+# Suppress specific false positive signatures as there is currently no way
+# using ClamAV configuration to exclude PUA subcategories:
+# https://docs.clamav.net/faq/faq-pua.html
+AV_SIGNATURE_FALSE_POSITIVES = ["PUA.Pdf.Trojan.EmbeddedJavaScript"]
 AV_SIGNATURE_METADATA = os.getenv("AV_SIGNATURE_METADATA", "av-signature")
 AV_SIGNATURE_OK = "OK"
 AV_SIGNATURE_UNKNOWN = "UNKNOWN"

--- a/api/tests/clamav/test_scan.py
+++ b/api/tests/clamav/test_scan.py
@@ -1,8 +1,9 @@
 from unittest.mock import patch, ANY, MagicMock
-from clamav_scanner.common import AV_SIGNATURE_OK
+from clamav_scanner.clamav import determine_verdict
+from clamav_scanner.common import AV_SIGNATURE_OK, AV_SIGNATURE_UNKNOWN
 from clamav_scanner.scan import launch_scan, sns_scan_results
 from factories import ScanFactory
-from models.Scan import ScanVerdicts
+from models.Scan import ScanProviders, ScanVerdicts
 
 
 @patch("clamav_scanner.scan.log")
@@ -126,3 +127,71 @@ def test_sns_scan_results_error(mock_db_session, mock_aws_session, session):
             "aws-account": {"DataType": "String", "StringValue": "210987654321"},
         },
     )
+
+
+@patch("clamav_scanner.clamav.log")
+def test_determine_verdict_clamav_clean(mock_log):
+    provider = ScanProviders.CLAMAV.value
+    path = "/test/path"
+    summary = {path: "clean", "Time": "1.000"}
+    av_proc = MagicMock()
+    av_proc.returncode = 0
+
+    verdict, signature = determine_verdict(provider, path, summary, av_proc)
+    assert verdict == ScanVerdicts.CLEAN.value
+    assert signature == "clean"
+
+
+@patch("clamav_scanner.clamav.log")
+def test_determine_verdict_clamav_false_positive(mock_log):
+    provider = ScanProviders.CLAMAV.value
+    path = "/test/path"
+    false_positive_signature = "PUA.Pdf.Trojan.EmbeddedJavaScript-1 FOUND"
+    summary = {path: false_positive_signature, "Time": "1.000"}
+    av_proc = MagicMock()
+    av_proc.returncode = 1
+
+    verdict, signature = determine_verdict(provider, path, summary, av_proc)
+    assert verdict == ScanVerdicts.CLEAN.value
+    assert signature == false_positive_signature
+
+
+@patch("clamav_scanner.clamav.log")
+def test_determine_verdict_clamav_malicious(mock_log):
+    provider = ScanProviders.CLAMAV.value
+    path = "/test/path"
+    summary = {path: "malicious", "Time": "1.000"}
+    av_proc = MagicMock()
+    av_proc.returncode = 1
+
+    verdict, signature = determine_verdict(provider, path, summary, av_proc)
+    assert verdict == ScanVerdicts.MALICIOUS.value
+    assert signature == "malicious"
+
+
+@patch("clamav_scanner.clamav.log")
+def test_determine_verdict_clamav_unable_to_scan(mock_log):
+    provider = ScanProviders.CLAMAV.value
+    path = "/test/path"
+    summary = {path: "unknown", "Time": "0.000"}
+    av_proc = MagicMock()
+    av_proc.returncode = 0
+
+    verdict, signature = determine_verdict(provider, path, summary, av_proc)
+    assert verdict == ScanVerdicts.UNABLE_TO_SCAN.value
+    assert signature == AV_SIGNATURE_UNKNOWN
+    mock_log.error.assert_called()
+
+
+@patch("clamav_scanner.clamav.log")
+def test_determine_verdict_clamav_error(mock_log):
+    provider = ScanProviders.CLAMAV.value
+    path = "/test/path"
+    summary = {path: "unknown", "Time": "1.000"}
+    av_proc = MagicMock()
+    av_proc.returncode = 2
+
+    verdict, signature = determine_verdict(provider, path, summary, av_proc)
+    assert verdict == ScanVerdicts.ERROR.value
+    assert signature == AV_SIGNATURE_UNKNOWN
+    mock_log.error.assert_called()


### PR DESCRIPTION
# Summary
Update the ClamAV scan so that Potentially Unwanted Apps (PUA) subcategories can be excluded.

Currently this is not possible with the ClamAV configuration and we are seeing cases where legitimate Government of Canada PDFs that contain JavaScript are being flagged as containing PUAs.

# Related
- https://github.com/cds-snc/notification-planning/issues/1636
- [**ClamAV PUAs**](https://docs.clamav.net/faq/faq-pua.html)