### PR TITLE
fix: update to latest Docker scan and generate SBOM actions

### DIFF
--- a/.github/workflows/build_and_push_production.yml
+++ b/.github/workflows/build_and_push_production.yml
@@ -72,7 +72,9 @@ jobs:
           docker push $REGISTRY/${{ matrix.image }}:latest
 
       - name: Docker generate SBOM
-        uses: cds-snc/security-tools/.github/actions/generate-sbom@598deeaed48ab3bb0df85f0ed124ba53f0ade385 # v3.1.0
+        uses: cds-snc/security-tools/.github/actions/generate-sbom@34794baf2af592913bb5b51d8df4f8d0acc49b6f # v3.2.0
+        env:
+          TRIVY_DB_REPOSITORY: ${{ vars.TRIVY_DB_REPOSITORY }}
         with:
           docker_image: "${{ env.REGISTRY }}/${{ matrix.image }}:${{ env.GITHUB_SHA }}"
           dockerfile_path: "${{ matrix.image }}/Dockerfile"

--- a/.github/workflows/build_and_push_staging.yml
+++ b/.github/workflows/build_and_push_staging.yml
@@ -113,7 +113,9 @@ jobs:
           retry-delay: 5s
 
       - name: Docker generate SBOM
-        uses: cds-snc/security-tools/.github/actions/generate-sbom@598deeaed48ab3bb0df85f0ed124ba53f0ade385 # v3.1.0
+        uses: cds-snc/security-tools/.github/actions/generate-sbom@34794baf2af592913bb5b51d8df4f8d0acc49b6f # v3.2.0
+        env:
+          TRIVY_DB_REPOSITORY: ${{ vars.TRIVY_DB_REPOSITORY }}
         with:
           docker_image: "${{ env.REGISTRY }}/${{ matrix.image }}:${{ env.GITHUB_SHA }}"
           dockerfile_path: "${{ matrix.image }}/Dockerfile"

--- a/.github/workflows/docker_vulnerability_scan.yml
+++ b/.github/workflows/docker_vulnerability_scan.yml
@@ -38,7 +38,9 @@ jobs:
         uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
 
       - name: Docker vulnerability scan
-        uses: cds-snc/security-tools/.github/actions/docker-scan@598deeaed48ab3bb0df85f0ed124ba53f0ade385 # v3.1.0
+        uses: cds-snc/security-tools/.github/actions/docker-scan@34794baf2af592913bb5b51d8df4f8d0acc49b6f # v3.2.0
+        env:
+          TRIVY_DB_REPOSITORY: ${{ vars.TRIVY_DB_REPOSITORY }}
         with:
           docker_image: "${{ env.REGISTRY }}/${{ matrix.image }}:latest"
           dockerfile_path: "${{ matrix.image }}/Dockerfile"


### PR DESCRIPTION
# Summary
Update to the latest scan/generate SBOM actions and provide our own Trivy DB repository URL, which is defined as an organizational variable.

This is being done to address the rate limiting errors we're intermittently getting using Trivy's default public DB repository.

# Related
- https://github.com/cds-snc/platform-core-services/issues/597