### PR TITLE
fix: use substitution for API definition ref

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -21,5 +21,6 @@ spec:
   lifecycle: experimental
   owner: group:cds-snc/internal-sre
   domain: site-reliability-engineering
-  definition: https://scan-files.alpha.canada.ca/openapi.json
+  definition: 
+    $json: https://scan-files.alpha.canada.ca/openapi.json
   


### PR DESCRIPTION
# Summary | Résumé

The API definition is a json file so Backstage needs to know it needs to parse it vs the definition being the actual definition.

Source: https://backstage.io/docs/features/software-catalog/descriptor-format/#substitutions-in-the-descriptor-format