### PR TITLE
fix: use $text substitutor

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -22,5 +22,5 @@ spec:
   owner: group:cds-snc/internal-sre
   domain: site-reliability-engineering
   definition: 
-    $json: https://scan-files.alpha.canada.ca/openapi.json
+    $text: https://scan-files.alpha.canada.ca/openapi.json
   


### PR DESCRIPTION
# Summary | Résumé

After testing with a different repo, using $text instead of $json seems to be working to parse the content of the file.

![image](https://github.com/user-attachments/assets/b8a6d267-a094-497e-8e7c-b6dbea5fb87c)
