### PR TITLE
fix: change logging level for warnings and above

### DIFF
--- a/terragrunt/aws/api/lambda.tf
+++ b/terragrunt/aws/api/lambda.tf
@@ -26,7 +26,7 @@ module "scan_files" {
     COMPLETED_SCANS_TABLE_NAME   = "completed-scans"
     FILE_CHECKSUM_TABLE_NAME     = "file-checksums"
     FILE_QUEUE_BUCKET            = module.file-queue.s3_bucket_id
-    LOG_LEVEL                    = "INFO"
+    LOG_LEVEL                    = "WARNING"
     OPENAPI_URL                  = "/openapi.json"
     POWERTOOLS_SERVICE_NAME      = "${var.product_name}-api"
     SCAN_QUEUE_STATEMACHINE_NAME = "assemblyline-file-scan-queue"

--- a/terragrunt/aws/s3_scan_object/lambda.tf
+++ b/terragrunt/aws/s3_scan_object/lambda.tf
@@ -10,7 +10,7 @@ module "s3_scan_object" {
   environment_variables = {
     AWS_MAX_ATTEMPTS              = "5"
     AWS_RETRY_MODE                = "standard"
-    LOGGING_LEVEL                 = "info"
+    LOGGING_LEVEL                 = "warn"
     SCAN_FILES_URL                = var.scan_files_api_function_url
     SCAN_FILES_API_KEY_SECRET_ARN = var.scan_files_api_key_secret_arn
     SNS_SCAN_COMPLETE_TOPIC_ARN   = aws_sns_topic.scan_complete.arn


### PR DESCRIPTION
# Summary
Update the logging levels to save on CloudWatch costs.