### PR TITLE
fix: encrypt SNS topics with CMK

### DIFF
--- a/terragrunt/aws/alarms/sns.tf
+++ b/terragrunt/aws/alarms/sns.tf
@@ -2,8 +2,8 @@
 # SNS: topic & subscription
 #
 resource "aws_sns_topic" "cloudwatch_warning" {
-  # checkov:skip=CKV_AWS_26: encryption-at-rest not required for alarm topic
-  name = "cloudwatch-alarms-warning"
+  name              = "cloudwatch-alarms-warning"
+  kms_master_key_id = aws_kms_key.sns_cloudwatch.id
 }
 
 resource "aws_sns_topic_subscription" "alert_warning" {
@@ -13,9 +13,9 @@ resource "aws_sns_topic_subscription" "alert_warning" {
 }
 
 resource "aws_sns_topic" "cloudwatch_warning_us_east" {
-  # checkov:skip=CKV_AWS_26: encryption-at-rest not required for alarm topic
-  provider = aws.us-east-1
-  name     = "cloudwatch-alarms-warning"
+  provider          = aws.us-east-1
+  name              = "cloudwatch-alarms-warning"
+  kms_master_key_id = aws_kms_key.sns_cloudwatch_us_east.id
 }
 
 resource "aws_sns_topic_subscription" "alert_warning_us_east" {
@@ -23,4 +23,51 @@ resource "aws_sns_topic_subscription" "alert_warning_us_east" {
   topic_arn = aws_sns_topic.cloudwatch_warning_us_east.arn
   protocol  = "https"
   endpoint  = var.slack_webhook_url
+}
+
+#
+# KMS: SNS topic encryption keys
+# A CMK is required so we can apply a policy that allows CloudWatch to use it
+#
+resource "aws_kms_key" "sns_cloudwatch" {
+  # checkov:skip=CKV_AWS_7: key rotation not required for CloudWatch SNS topic's messages
+  description = "KMS key for CloudWatch SNS topic"
+  policy      = data.aws_iam_policy_document.sns_cloudwatch.json
+}
+
+resource "aws_kms_key" "sns_cloudwatch_us_east" {
+  # checkov:skip=CKV_AWS_7: key rotation not required for CloudWatch SNS topic's messages
+  provider = aws.us-east-1
+
+  description = "KMS key for CloudWatch SNS topic in US east"
+  policy      = data.aws_iam_policy_document.sns_cloudwatch.json
+}
+
+data "aws_iam_policy_document" "sns_cloudwatch" {
+  # checkov:skip=CKV_AWS_109: `resources = ["*"]` identifies the KMS key to which the key policy is attached
+  # checkov:skip=CKV_AWS_111: `resources = ["*"]` identifies the KMS key to which the key policy is attached
+  statement {
+    effect    = "Allow"
+    resources = ["*"]
+    actions   = ["kms:*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${var.account_id}:root"]
+    }
+  }
+
+  statement {
+    effect    = "Allow"
+    resources = ["*"]
+    actions = [
+      "kms:Decrypt",
+      "kms:GenerateDataKey*",
+    ]
+
+    principals {
+      type        = "Service"
+      identifiers = ["cloudwatch.amazonaws.com"]
+    }
+  }
 }


### PR DESCRIPTION
# Summary
Add a Customer Managed Key to encrypt the CloudWatch alarm SNS topics.

This is required to satisfy the SSC Config Conformance pack guardrails.

# Related
- https://github.com/cds-snc/platform-core-services/issues/787