### PR TITLE
use org secrets for sentinel forwarder

### DIFF
--- a/.github/workflows/tf_apply_production.yml
+++ b/.github/workflows/tf_apply_production.yml
@@ -16,8 +16,8 @@ env:
   TF_VAR_aws_org_id_old: ${{ secrets.AWS_ORG_ID_OLD }}
   TF_VAR_rds_password: ${{ secrets.PRODUCTION_RDS_PASSWORD }}
   TF_VAR_slack_webhook_url: ${{ secrets.SCAN_FILES_PROD_OPS_WEBHOOK }}
-  TF_VAR_sentinel_customer_id: ${{ secrets.SENTINEL_CUSTOMER_ID }}
-  TF_VAR_sentinel_shared_key: ${{ secrets.SENTINEL_SHARED_KEY }}
+  TF_VAR_sentinel_customer_id: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
+  TF_VAR_sentinel_shared_key: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
   AWS_REGION: ca-central-1
 
 permissions:

--- a/.github/workflows/tf_apply_staging.yml
+++ b/.github/workflows/tf_apply_staging.yml
@@ -18,8 +18,8 @@ env:
   TF_VAR_aws_org_id_old: ${{ secrets.AWS_ORG_ID_OLD }}
   TF_VAR_rds_password: ${{ secrets.STAGING_RDS_PASSWORD }}
   TF_VAR_slack_webhook_url: ${{ secrets.SCAN_FILES_STAGING_OPS_WEBHOOK }}
-  TF_VAR_sentinel_customer_id: ${{ secrets.SENTINEL_CUSTOMER_ID }}
-  TF_VAR_sentinel_shared_key: ${{ secrets.SENTINEL_SHARED_KEY }}
+  TF_VAR_sentinel_customer_id: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
+  TF_VAR_sentinel_shared_key: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
   AWS_REGION: ca-central-1
 
 permissions:

--- a/.github/workflows/tf_plan_production.yml
+++ b/.github/workflows/tf_plan_production.yml
@@ -17,9 +17,8 @@ env:
   TF_VAR_aws_org_id_old: ${{ secrets.AWS_ORG_ID_OLD }}
   TF_VAR_rds_password: ${{ secrets.PRODUCTION_RDS_PASSWORD }}
   TF_VAR_slack_webhook_url: ${{ secrets.SCAN_FILES_PROD_OPS_WEBHOOK }}
-  TF_VAR_sentinel_customer_id: ${{ secrets.SENTINEL_CUSTOMER_ID }}
-  TF_VAR_sentinel_shared_key: ${{ secrets.SENTINEL_SHARED_KEY }}
-
+  TF_VAR_sentinel_customer_id: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
+  TF_VAR_sentinel_shared_key: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
 permissions:
   id-token: write
   contents: read

--- a/.github/workflows/tf_plan_staging.yml
+++ b/.github/workflows/tf_plan_staging.yml
@@ -19,8 +19,8 @@ env:
   TF_VAR_aws_org_id_old: ${{ secrets.AWS_ORG_ID_OLD }}
   TF_VAR_rds_password: ${{ secrets.STAGING_RDS_PASSWORD }}
   TF_VAR_slack_webhook_url: ${{ secrets.SCAN_FILES_STAGING_OPS_WEBHOOK }}
-  TF_VAR_sentinel_customer_id: ${{ secrets.SENTINEL_CUSTOMER_ID }}
-  TF_VAR_sentinel_shared_key: ${{ secrets.SENTINEL_SHARED_KEY }}
+  TF_VAR_sentinel_customer_id: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
+  TF_VAR_sentinel_shared_key: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}
 
 permissions:
   id-token: write


### PR DESCRIPTION
# Summary | Résumé

This PR changes the sentinel customer id and shared key to use the org secrets. 
